### PR TITLE
Add more options for ECDSA signing algorithms

### DIFF
--- a/secom-core-jakarta/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
+++ b/secom-core-jakarta/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
@@ -71,7 +71,7 @@ public enum DigitalSignatureAlgorithmEnum implements SECOM_Enum {
      */
     public static DigitalSignatureAlgorithmEnum fromValue(String value) {
         return Arrays.stream(DigitalSignatureAlgorithmEnum.values())
-                .filter(t -> t.getValue().compareTo(value) == 0)
+                .filter(t -> t.getValue().equalsIgnoreCase(value))
                 .findFirst()
                 .orElse(null);
     }

--- a/secom-core-jakarta/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
+++ b/secom-core-jakarta/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
@@ -31,13 +31,13 @@ import java.util.Arrays;
 public enum DigitalSignatureAlgorithmEnum implements SECOM_Enum {
     @JsonProperty("dsa")
     DSA("SHA3-384withDSA"),
-    @JsonProperty("ECDSA-256-SHA2-256")
+    @JsonProperty("ecdsa-256-sha2-256")
     SHA2_256_WITH_ECDSA("SHA256withECDSA"),
-    @JsonProperty("ECDSA-256-SHA3-256")
+    @JsonProperty("ecdsa-256-sha3-256")
     SHA3_256_WITH_ECDSA("SHA3-256withECDSA"),
-    @JsonProperty("ECDSA-384-SHA2")
+    @JsonProperty("ecdsa-384-sha2")
     SHA2_384_WITH_ECDSA("SHA384withECDSA"),
-    @JsonProperty("ECDSA-384-SHA3")
+    @JsonProperty("ecdsa-384-sha3")
     SHA3_384_WITH_ECDSA("SHA3-384withECDSA"),
     @JsonProperty("cvc_ecdsa")
     CVC_ECDSA("SHA-384withCVC-ECDSA");

--- a/secom-core-jakarta/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
+++ b/secom-core-jakarta/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
@@ -31,8 +31,14 @@ import java.util.Arrays;
 public enum DigitalSignatureAlgorithmEnum implements SECOM_Enum {
     @JsonProperty("dsa")
     DSA("SHA3-384withDSA"),
-    @JsonProperty("ecdsa")
-    ECDSA("SHA3-384withECDSA"),
+    @JsonProperty("ECDSA-256-SHA2-256")
+    SHA2_256_WITH_ECDSA("SHA256withECDSA"),
+    @JsonProperty("ECDSA-256-SHA3-256")
+    SHA3_256_WITH_ECDSA("SHA3-256withECDSA"),
+    @JsonProperty("ECDSA-384-SHA2")
+    SHA2_384_WITH_ECDSA("SHA384withECDSA"),
+    @JsonProperty("ECDSA-384-SHA3")
+    SHA3_384_WITH_ECDSA("SHA3-384withECDSA"),
     @JsonProperty("cvc_ecdsa")
     CVC_ECDSA("SHA-384withCVC-ECDSA");
 

--- a/secom-core/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
+++ b/secom-core/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
@@ -71,7 +71,7 @@ public enum DigitalSignatureAlgorithmEnum implements SECOM_Enum {
      */
     public static DigitalSignatureAlgorithmEnum fromValue(String value) {
         return Arrays.stream(DigitalSignatureAlgorithmEnum.values())
-                .filter(t -> t.getValue().compareTo(value) == 0)
+                .filter(t -> t.getValue().equalsIgnoreCase(value))
                 .findFirst()
                 .orElse(null);
     }

--- a/secom-core/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
+++ b/secom-core/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
@@ -31,13 +31,13 @@ import java.util.Arrays;
 public enum DigitalSignatureAlgorithmEnum implements SECOM_Enum {
     @JsonProperty("dsa")
     DSA("SHA3-384withDSA"),
-    @JsonProperty("ECDSA-256-SHA2-256")
+    @JsonProperty("ecdsa-256-sha2-256")
     SHA2_256_WITH_ECDSA("SHA256withECDSA"),
-    @JsonProperty("ECDSA-256-SHA3-256")
+    @JsonProperty("ecdsa-256-sha3-256")
     SHA3_256_WITH_ECDSA("SHA3-256withECDSA"),
-    @JsonProperty("ECDSA-384-SHA2")
+    @JsonProperty("ecdsa-384-sha2")
     SHA2_384_WITH_ECDSA("SHA384withECDSA"),
-    @JsonProperty("ECDSA-384-SHA3")
+    @JsonProperty("ecdsa-384-sha3")
     SHA3_384_WITH_ECDSA("SHA3-384withECDSA"),
     @JsonProperty("cvc_ecdsa")
     CVC_ECDSA("SHA-384withCVC-ECDSA");

--- a/secom-core/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
+++ b/secom-core/src/main/java/org/grad/secom/core/models/enums/DigitalSignatureAlgorithmEnum.java
@@ -31,8 +31,14 @@ import java.util.Arrays;
 public enum DigitalSignatureAlgorithmEnum implements SECOM_Enum {
     @JsonProperty("dsa")
     DSA("SHA3-384withDSA"),
-    @JsonProperty("ecdsa")
-    ECDSA("SHA3-384withECDSA"),
+    @JsonProperty("ECDSA-256-SHA2-256")
+    SHA2_256_WITH_ECDSA("SHA256withECDSA"),
+    @JsonProperty("ECDSA-256-SHA3-256")
+    SHA3_256_WITH_ECDSA("SHA3-256withECDSA"),
+    @JsonProperty("ECDSA-384-SHA2")
+    SHA2_384_WITH_ECDSA("SHA384withECDSA"),
+    @JsonProperty("ECDSA-384-SHA3")
+    SHA3_384_WITH_ECDSA("SHA3-384withECDSA"),
     @JsonProperty("cvc_ecdsa")
     CVC_ECDSA("SHA-384withCVC-ECDSA");
 


### PR DESCRIPTION
This makes it possible to better match key length, hash function and hash length.

Additionally, the serialized names have been aligned with the values from S-100 5.1.0 Table 15-8.11.7.