### PR TITLE
Add Jandex index to secom-core-jakarta jar file

### DIFF
--- a/secom-core-jakarta/pom.xml
+++ b/secom-core-jakarta/pom.xml
@@ -114,5 +114,21 @@
         </dependency>
 
     </dependencies>
-
+<build>
+  <plugins>
+    <plugin>
+      <groupId>io.smallrye</groupId>
+      <artifactId>jandex-maven-plugin</artifactId>
+      <version>3.2.2</version>
+      <executions>
+        <execution>
+          <id>make-index</id>
+          <goals>
+            <goal>jandex</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
 </project>

--- a/secom-core-jakarta/pom.xml
+++ b/secom-core-jakarta/pom.xml
@@ -114,21 +114,22 @@
         </dependency>
 
     </dependencies>
-<build>
-  <plugins>
-    <plugin>
-      <groupId>io.smallrye</groupId>
-      <artifactId>jandex-maven-plugin</artifactId>
-      <version>3.2.2</version>
-      <executions>
-        <execution>
-          <id>make-index</id>
-          <goals>
-            <goal>jandex</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-</build>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.2.2</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Generate a Jandex index at built time. 

This will allow Quarkus to use the SECOM library out of the box.
Currently Providers are not being picked up.
The index is around 40 kb