### PR TITLE
Add POST Get Summary interface in accordance with 80/1186/CD (SECOM CD3)

### DIFF
--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
@@ -129,6 +129,10 @@ public class SecomSignatureFilter implements ContainerRequestFilter {
             else if (rqstCtx.getUriInfo().getPath().endsWith(SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH)){
                 obj = this.parseRequestBody(rqstCtx, SearchFilterObject.class);
             }
+            // For the POST Get Summary Interface Requests
+            else if (rqstCtx.getUriInfo().getPath().endsWith(PostGetSummaryServiceInterface.POST_GET_SUMMARY_INTERFACE_PATH)){
+                obj = this.parseRequestBody(rqstCtx, GetSummaryFilterObject.class);
+            }
         }
 
         // If we have an object, validate the signatures

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -41,6 +41,7 @@ import static org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface.ENC
 import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetSummaryServiceInterface.POST_GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionServiceInterface.SUBSCRIPTION_INTERFACE_PATH;
@@ -148,6 +149,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     }
                 case GET_SUMMARY_INTERFACE_PATH:
                     return GetSummaryServiceInterface.handleGetSummaryInterfaceExceptions(ex, this.request, null);
+                case POST_GET_SUMMARY_INTERFACE_PATH:
+                    return PostGetSummaryServiceInterface.handleGetSummaryInterfaceExceptions(ex, this.request, null);
                 case PING_INTERFACE_PATH:
                     return PingServiceInterface.handlePingInterfaceExceptions(ex, this.request, null);
                 case SUBSCRIPTION_INTERFACE_PATH: // Also for remove subscription

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomSchemaValidationException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.GetSummaryFilterObject;
+import org.grad.secomv2.core.models.GetSummaryResponseObject;
+
+/**
+ * The SECOM POST Get Summary Interface Definition.
+ * </p>
+ * This interface definition can be used by the SECOM-compliant services in
+ * order to direct the implementation of the relevant endpoint according to
+ * the specified SECOM standard version.
+ *
+ * @author Changyun Lee (email: changyun.lee@aivenautics.com)
+ */
+public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
+
+    /**
+     * The Interface Endpoint Path.
+     */
+    String POST_GET_SUMMARY_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/object/search/summary";
+
+    /**
+     * POST /v2/object/search/summary :  A list of information shall be returned from
+     * this interface. The summary contains identity, status and short
+     * description of each information object. The actual information object
+     * shall be retrieved using the Get interface.
+     *
+     * @param getSummaryFilterObject the get summary filter object
+     * @return the summary response object
+     */
+    @Path(POST_GET_SUMMARY_INTERFACE_PATH)
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    GetSummaryResponseObject getSummary(@Valid GetSummaryFilterObject getSummaryFilterObject);
+
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleGetSummaryInterfaceExceptions(Exception ex,
+                                                        HttpServletRequest request,
+                                                        HttpServletResponse response) {
+        // Create the get summary response
+        Response.Status responseStatus;
+        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+
+        // Handle according to the exception type
+        if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException
+                || ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatus = Response.Status.BAD_REQUEST;
+        } else if(ex instanceof SecomNotAuthorisedException) {
+            responseStatus = Response.Status.FORBIDDEN;
+        } else if(ex instanceof SecomNotFoundException) {
+            responseStatus = Response.Status.NOT_FOUND;
+        } else if(ex instanceof SecomSchemaValidationException) {
+            responseStatus = Response.Status.fromStatusCode(422);
+        } else {
+            responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
+        }
+
+        // And send the error response back
+        return Response.status(responseStatus)
+                .entity(getSummaryResponseObject)
+                .build();
+    }
+
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObject.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import org.grad.secomv2.core.base.SecomInstantDeserializer;
+import org.grad.secomv2.core.base.SecomInstantSerializer;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+
+import java.time.Instant;
+
+/**
+ * The SECOM Envelope Get Summary Filter Object Class
+ *
+ * @author Changyun Lee (email: changyun.lee@aivenautics.com)
+ */
+public class EnvelopeGetSummaryFilterObject extends AbstractEnvelope {
+
+    // Class Variables
+    @Schema(description = "Container type requested")
+    private ContainerTypeEnum containerType;
+    @Schema(description = "Data product type name requested", example = "S-124")
+    private SECOM_DataProductType dataProductType;
+    @Schema(description = "S-100 based Product type version requested", example = "2.0.0")
+    private String productVersion;
+    @Schema(description = "Geometry condition for geo-located information objects", type = "string", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
+    @Pattern(regexp = "^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$")
+    private String geometry;
+    @Schema(description = "Code of defined object See: https://unece.org/trade/cefact/unlocode-code-list-country-and-territory", type = "string", example = "GBHRW")
+    @Pattern(regexp = "[A-Z]{5}")
+    private String unlocode;
+    @Schema(description = "Time related to validity period start for information object", type = "string", example = "1985-04-12T10:15:30Z", pattern =  "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|\\+\\d{4})?")
+    @JsonSerialize(using = SecomInstantSerializer.class)
+    @JsonDeserialize(using = SecomInstantDeserializer.class)
+    private Instant validFrom;
+    @Schema(description = "Time related to validity period end for information object", type = "string", example = "1985-04-12T10:15:30Z", pattern =  "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|\\+\\d{4})?")
+    @JsonSerialize(using = SecomInstantSerializer.class)
+    @JsonDeserialize(using = SecomInstantDeserializer.class)
+    private Instant validTo;
+    @Schema(description = "Requested pagination page. Must be a positive integer >= 1..", defaultValue = "1")
+    private Integer page;
+    @Schema(description = "Requested pagination page size. Must be a positive integer >= 0.", defaultValue = "100")
+    private Integer pageSize;
+
+    /**
+     * Gets container type.
+     *
+     * @return the container type
+     */
+    public ContainerTypeEnum getContainerType() {
+        return containerType;
+    }
+
+    /**
+     * Sets container type.
+     *
+     * @param containerType the container type
+     */
+    public void setContainerType(ContainerTypeEnum containerType) {
+        this.containerType = containerType;
+    }
+
+    /**
+     * Gets data product type.
+     *
+     * @return the data product type
+     */
+    public SECOM_DataProductType getDataProductType() {
+        return dataProductType;
+    }
+
+    /**
+     * Sets data product type.
+     *
+     * @param dataProductType the data product type
+     */
+    public void setDataProductType(SECOM_DataProductType dataProductType) {
+        this.dataProductType = dataProductType;
+    }
+
+    /**
+     * Gets product version.
+     *
+     * @return the product version
+     */
+    public String getProductVersion() {
+        return productVersion;
+    }
+
+    /**
+     * Sets product version.
+     *
+     * @param productVersion the product version
+     */
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
+
+    /**
+     * Gets geometry.
+     *
+     * @return the geometry
+     */
+    public String getGeometry() {
+        return geometry;
+    }
+
+    /**
+     * Sets geometry.
+     *
+     * @param geometry the geometry
+     */
+    public void setGeometry(String geometry) {
+        this.geometry = geometry;
+    }
+
+    /**
+     * Gets unlocode.
+     *
+     * @return the unlocode
+     */
+    public String getUnlocode() {
+        return unlocode;
+    }
+
+    /**
+     * Sets unlocode.
+     *
+     * @param unlocode the unlocode
+     */
+    public void setUnlocode(String unlocode) {
+        this.unlocode = unlocode;
+    }
+
+    /**
+     * Gets valid from.
+     *
+     * @return the valid from
+     */
+    public Instant getValidFrom() {
+        return validFrom;
+    }
+
+    /**
+     * Sets valid from.
+     *
+     * @param validFrom the valid from
+     */
+    public void setValidFrom(Instant validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    /**
+     * Gets valid to.
+     *
+     * @return the valid to
+     */
+    public Instant getValidTo() {
+        return validTo;
+    }
+
+    /**
+     * Sets valid to.
+     *
+     * @param validTo the valid to
+     */
+    public void setValidTo(Instant validTo) {
+        this.validTo = validTo;
+    }
+
+    /**
+     * Gets page.
+     *
+     * @return the page
+     */
+    public Integer getPage() {
+        return page;
+    }
+
+    /**
+     * Sets page.
+     *
+     * @param page the page
+     */
+    public void setPage(Integer page) {
+        this.page = page;
+    }
+
+    /**
+     * Gets page size.
+     *
+     * @return the page size
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets page size.
+     *
+     * @param pageSize the page size
+     */
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[] {
+                containerType,
+                dataProductType,
+                productVersion,
+                geometry,
+                unlocode,
+                validFrom,
+                validTo,
+                page,
+                pageSize,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime
+        };
+    }
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetSummaryFilterObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetSummaryFilterObject.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import jakarta.validation.constraints.NotNull;
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+/**
+ * The SECOM Get Summary Filter Object Class
+ *
+ * @author Changyun Lee (email: changyun.lee@aivenautics.com)
+ */
+public class GetSummaryFilterObject implements EnvelopeSignatureBearer {
+
+    // Class Variables
+    @NotNull
+    private EnvelopeGetSummaryFilterObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Gets envelope.
+     *
+     * @return the envelope
+     */
+    @Override
+    public EnvelopeGetSummaryFilterObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets envelope.
+     *
+     * @param envelope the envelope
+     */
+    public void setEnvelope(EnvelopeGetSummaryFilterObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets envelope signature.
+     *
+     * @return the envelope signature
+     */
+    @Override
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets envelope signature.
+     *
+     * @param digitalSignature the envelope signature
+     */
+    @Override
+    public void setEnvelopeSignature(String digitalSignature) {
+        this.envelopeSignature = digitalSignature;
+    }
+}

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObjectTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvelopeGetSummaryFilterObjectTest {
+
+    // Class Variables
+    private EnvelopeGetSummaryFilterObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Generate a new object
+        this.obj = new EnvelopeGetSummaryFilterObject();
+        this.obj.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.obj.setDataProductType(SECOM_DataProductType.S101);
+        this.obj.setProductVersion("version");
+        this.obj.setGeometry("geometry");
+        this.obj.setUnlocode("unlocode");
+        this.obj.setValidFrom(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.obj.setValidTo(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.obj.setPage(1);
+        this.obj.setPageSize(100);
+        this.obj.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.obj.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.obj.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        EnvelopeGetSummaryFilterObject result = this.mapper.readValue(jsonString, EnvelopeGetSummaryFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertEquals(this.obj.getContainerType(), result.getContainerType());
+        assertEquals(this.obj.getDataProductType(), result.getDataProductType());
+        assertEquals(this.obj.getProductVersion(), result.getProductVersion());
+        assertEquals(this.obj.getGeometry(), result.getGeometry());
+        assertEquals(this.obj.getUnlocode(), result.getUnlocode());
+        assertEquals(this.obj.getValidFrom(), result.getValidFrom());
+        assertEquals(this.obj.getValidTo(), result.getValidTo());
+        assertEquals(this.obj.getPage(), result.getPage());
+        assertEquals(this.obj.getPageSize(), result.getPageSize());
+        assertArrayEquals(this.obj.getEnvelopeSignatureCertificate(), result.getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), result.getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelopeSignatureTime(), result.getEnvelopeSignatureTime());
+    }
+
+    /**
+     * Test that we can correctly generate the SECOM signature CSV.
+     */
+    @Test
+    void testGetCsvString() {
+        // Generate the signature CSV
+        String signatureCSV = this.obj.getCsvString();
+
+        // Match the individual entries of the string
+        String[] csv = signatureCSV.split("\\.");
+        assertEquals(String.valueOf(this.obj.getContainerType().getValue()), csv[0]);
+        assertEquals(this.obj.getDataProductType().getValue(), csv[1]);
+        assertEquals(this.obj.getProductVersion(), csv[2]);
+        assertEquals(this.obj.getGeometry(), csv[3]);
+        assertEquals(this.obj.getUnlocode(), csv[4]);
+        assertEquals(String.valueOf(this.obj.getValidFrom().getEpochSecond()), csv[5]);
+        assertEquals(String.valueOf(this.obj.getValidTo().getEpochSecond()), csv[6]);
+        assertEquals(String.valueOf(this.obj.getPage()), csv[7]);
+        assertEquals(String.valueOf(this.obj.getPageSize()), csv[8]);
+        assertEquals(Arrays.toString(this.obj.getEnvelopeSignatureCertificate()), csv[9]);
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), csv[10]);
+        assertEquals(String.valueOf(this.obj.getEnvelopeSignatureTime().getEpochSecond()), csv[11]);
+    }
+
+}

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetSummaryFilterObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetSummaryFilterObjectTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetSummaryFilterObjectTest {
+
+    // Class Variables
+    private EnvelopeGetSummaryFilterObject envelopeGetSummaryFilterObject;
+    private GetSummaryFilterObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a new envelope get summary filter object
+        this.envelopeGetSummaryFilterObject = new EnvelopeGetSummaryFilterObject();
+        this.envelopeGetSummaryFilterObject.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.envelopeGetSummaryFilterObject.setDataProductType(SECOM_DataProductType.S101);
+        this.envelopeGetSummaryFilterObject.setProductVersion("version");
+        this.envelopeGetSummaryFilterObject.setGeometry("geometry");
+        this.envelopeGetSummaryFilterObject.setUnlocode("unlocode");
+        this.envelopeGetSummaryFilterObject.setValidFrom(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.envelopeGetSummaryFilterObject.setValidTo(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.envelopeGetSummaryFilterObject.setPage(1);
+        this.envelopeGetSummaryFilterObject.setPageSize(100);
+        this.envelopeGetSummaryFilterObject.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.envelopeGetSummaryFilterObject.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.envelopeGetSummaryFilterObject.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // Generate a new object
+        this.obj = new GetSummaryFilterObject();
+        this.obj.setEnvelope(this.envelopeGetSummaryFilterObject);
+        this.obj.setEnvelopeSignature("envelopeSignature");
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetSummaryFilterObject result = this.mapper.readValue(jsonString, GetSummaryFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertNotNull(result.getEnvelope());
+        assertEquals(this.obj.getEnvelope().getContainerType(), result.getEnvelope().getContainerType());
+        assertEquals(this.obj.getEnvelope().getDataProductType(), result.getEnvelope().getDataProductType());
+        assertEquals(this.obj.getEnvelope().getProductVersion(), result.getEnvelope().getProductVersion());
+        assertEquals(this.obj.getEnvelope().getGeometry(), result.getEnvelope().getGeometry());
+        assertEquals(this.obj.getEnvelope().getUnlocode(), result.getEnvelope().getUnlocode());
+        assertEquals(this.obj.getEnvelope().getValidFrom(), result.getEnvelope().getValidFrom());
+        assertEquals(this.obj.getEnvelope().getValidTo(), result.getEnvelope().getValidTo());
+        assertEquals(this.obj.getEnvelope().getPage(), result.getEnvelope().getPage());
+        assertEquals(this.obj.getEnvelope().getPageSize(), result.getEnvelope().getPageSize());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertEquals(this.obj.getEnvelopeSignature(), result.getEnvelopeSignature());
+    }
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
@@ -23,6 +23,7 @@ import org.grad.secomv2.core.exceptions.SecomInvalidCertificateException;
 import org.grad.secomv2.core.exceptions.SecomSignatureVerificationException;
 import org.grad.secomv2.core.interfaces.AcknowledgementServiceInterface;
 import org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface;
+import org.grad.secomv2.core.interfaces.PostGetSummaryServiceInterface;
 import org.grad.secomv2.core.interfaces.UploadLinkServiceInterface;
 import org.grad.secomv2.core.interfaces.UploadServiceInterface;
 import org.grad.secomv2.core.models.enums.DigitalSignatureAlgorithmEnum;
@@ -127,6 +128,10 @@ public class SecomSignatureFilter implements ContainerRequestFilter {
             // For the Encryption Key Interface Requests
             else if (rqstCtx.getUriInfo().getPath().endsWith(EncryptionKeyServiceInterface.ENCRYPTION_KEY_INTERFACE_PATH)) {
                 obj = this.parseRequestBody(rqstCtx, EncryptionKeyRequestObject.class);
+            }
+            // For the POST Get Summary Interface Requests
+            else if (rqstCtx.getUriInfo().getPath().endsWith(PostGetSummaryServiceInterface.POST_GET_SUMMARY_INTERFACE_PATH)){
+                obj = this.parseRequestBody(rqstCtx, GetSummaryFilterObject.class);
             }
         }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -40,6 +40,7 @@ import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_
 import static org.grad.secomv2.core.interfaces.GetPublicKeyServiceInterface.GET_PUBLIC_KEY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetSummaryServiceInterface.POST_GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
@@ -148,6 +149,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     }
                 case GET_SUMMARY_INTERFACE_PATH:
                     return GetSummaryServiceInterface.handleGetSummaryInterfaceExceptions(ex, this.request, null);
+                case POST_GET_SUMMARY_INTERFACE_PATH:
+                    return PostGetSummaryServiceInterface.handleGetSummaryInterfaceExceptions(ex, this.request, null);
                 case PING_INTERFACE_PATH:
                     return PingServiceInterface.handlePingInterfaceExceptions(ex, this.request, null);
                 case SUBSCRIPTION_INTERFACE_PATH: // Also for remove subscription

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomSchemaValidationException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.GetSummaryFilterObject;
+import org.grad.secomv2.core.models.GetSummaryResponseObject;
+
+/**
+ * The SECOM POST Get Summary Interface Definition.
+ * </p>
+ * This interface definition can be used by the SECOM-compliant services in
+ * order to direct the implementation of the relevant endpoint according to
+ * the specified SECOM standard version.
+ *
+ * @author Changyun Lee (email: changyun.lee@aivenautics.com)
+ */
+public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
+
+    /**
+     * The Interface Endpoint Path.
+     */
+    String POST_GET_SUMMARY_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/object/search/summary";
+
+    /**
+     * POST /v2/object/search/summary :  A list of information shall be returned from
+     * this interface. The summary contains identity, status and short
+     * description of each information object. The actual information object
+     * shall be retrieved using the Get interface.
+     *
+     * @param getSummaryFilterObject the get summary filter object
+     * @return the summary response object
+     */
+    @Path(POST_GET_SUMMARY_INTERFACE_PATH)
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    GetSummaryResponseObject getSummary(@Valid GetSummaryFilterObject getSummaryFilterObject);
+
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleGetSummaryInterfaceExceptions(Exception ex,
+                                                        HttpServletRequest request,
+                                                        HttpServletResponse response) {
+        // Create the get summary response
+        Response.Status responseStatus;
+        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+
+        // Handle according to the exception type
+        if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException
+                || ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatus = Response.Status.BAD_REQUEST;
+        } else if(ex instanceof SecomNotAuthorisedException) {
+            responseStatus = Response.Status.FORBIDDEN;
+        } else if(ex instanceof SecomNotFoundException) {
+            responseStatus = Response.Status.NOT_FOUND;
+        } else if(ex instanceof SecomSchemaValidationException) {
+            responseStatus = Response.Status.fromStatusCode(422);
+        } else {
+            responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
+        }
+
+        // And send the error response back
+        return Response.status(responseStatus)
+                .entity(getSummaryResponseObject)
+                .build();
+    }
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObject.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Pattern;
+import org.grad.secomv2.core.base.SecomInstantDeserializer;
+import org.grad.secomv2.core.base.SecomInstantSerializer;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+
+import java.time.Instant;
+
+/**
+ * The SECOM Envelope Get Summary Filter Object Class
+ *
+ * @author Changyun Lee (email: changyun.lee@aivenautics.com)
+ */
+public class EnvelopeGetSummaryFilterObject extends AbstractEnvelope {
+
+    // Class Variables
+    @Schema(description = "Container type requested")
+    private ContainerTypeEnum containerType;
+    @Schema(description = "Data product type name requested", example = "S-124")
+    private SECOM_DataProductType dataProductType;
+    @Schema(description = "S-100 based Product type version requested", example = "2.0.0")
+    private String productVersion;
+    @Schema(description = "Geometry condition for geo-located information objects", type = "string", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
+    @Pattern(regexp = "^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$")
+    private String geometry;
+    @Schema(description = "Code of defined object See: https://unece.org/trade/cefact/unlocode-code-list-country-and-territory", type = "string", example = "GBHRW")
+    @Pattern(regexp = "[A-Z]{5}")
+    private String unlocode;
+    @Schema(description = "Time related to validity period start for information object", type = "string", example = "1985-04-12T10:15:30Z", pattern =  "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|\\+\\d{4})?")
+    @JsonSerialize(using = SecomInstantSerializer.class)
+    @JsonDeserialize(using = SecomInstantDeserializer.class)
+    private Instant validFrom;
+    @Schema(description = "Time related to validity period end for information object", type = "string", example = "1985-04-12T10:15:30Z", pattern =  "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|\\+\\d{4})?")
+    @JsonSerialize(using = SecomInstantSerializer.class)
+    @JsonDeserialize(using = SecomInstantDeserializer.class)
+    private Instant validTo;
+    @Schema(description = "Requested pagination page. Must be a positive integer >= 1..", defaultValue = "1")
+    private Integer page;
+    @Schema(description = "Requested pagination page size. Must be a positive integer >= 0.", defaultValue = "100")
+    private Integer pageSize;
+
+    /**
+     * Gets container type.
+     *
+     * @return the container type
+     */
+    public ContainerTypeEnum getContainerType() {
+        return containerType;
+    }
+
+    /**
+     * Sets container type.
+     *
+     * @param containerType the container type
+     */
+    public void setContainerType(ContainerTypeEnum containerType) {
+        this.containerType = containerType;
+    }
+
+    /**
+     * Gets data product type.
+     *
+     * @return the data product type
+     */
+    public SECOM_DataProductType getDataProductType() {
+        return dataProductType;
+    }
+
+    /**
+     * Sets data product type.
+     *
+     * @param dataProductType the data product type
+     */
+    public void setDataProductType(SECOM_DataProductType dataProductType) {
+        this.dataProductType = dataProductType;
+    }
+
+    /**
+     * Gets product version.
+     *
+     * @return the product version
+     */
+    public String getProductVersion() {
+        return productVersion;
+    }
+
+    /**
+     * Sets product version.
+     *
+     * @param productVersion the product version
+     */
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
+
+    /**
+     * Gets geometry.
+     *
+     * @return the geometry
+     */
+    public String getGeometry() {
+        return geometry;
+    }
+
+    /**
+     * Sets geometry.
+     *
+     * @param geometry the geometry
+     */
+    public void setGeometry(String geometry) {
+        this.geometry = geometry;
+    }
+
+    /**
+     * Gets unlocode.
+     *
+     * @return the unlocode
+     */
+    public String getUnlocode() {
+        return unlocode;
+    }
+
+    /**
+     * Sets unlocode.
+     *
+     * @param unlocode the unlocode
+     */
+    public void setUnlocode(String unlocode) {
+        this.unlocode = unlocode;
+    }
+
+    /**
+     * Gets valid from.
+     *
+     * @return the valid from
+     */
+    public Instant getValidFrom() {
+        return validFrom;
+    }
+
+    /**
+     * Sets valid from.
+     *
+     * @param validFrom the valid from
+     */
+    public void setValidFrom(Instant validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    /**
+     * Gets valid to.
+     *
+     * @return the valid to
+     */
+    public Instant getValidTo() {
+        return validTo;
+    }
+
+    /**
+     * Sets valid to.
+     *
+     * @param validTo the valid to
+     */
+    public void setValidTo(Instant validTo) {
+        this.validTo = validTo;
+    }
+
+    /**
+     * Gets page.
+     *
+     * @return the page
+     */
+    public Integer getPage() {
+        return page;
+    }
+
+    /**
+     * Sets page.
+     *
+     * @param page the page
+     */
+    public void setPage(Integer page) {
+        this.page = page;
+    }
+
+    /**
+     * Gets page size.
+     *
+     * @return the page size
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets page size.
+     *
+     * @param pageSize the page size
+     */
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[] {
+                containerType,
+                dataProductType,
+                productVersion,
+                geometry,
+                unlocode,
+                validFrom,
+                validTo,
+                page,
+                pageSize,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime
+        };
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetSummaryFilterObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetSummaryFilterObject.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import javax.validation.constraints.NotNull;
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+/**
+ * The SECOM Get Summary Filter Object Class
+ *
+ * @author Changyun Lee (email: changyun.lee@aivenautics.com)
+ */
+public class GetSummaryFilterObject implements EnvelopeSignatureBearer {
+
+    // Class Variables
+    @NotNull
+    private EnvelopeGetSummaryFilterObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Gets envelope.
+     *
+     * @return the envelope
+     */
+    @Override
+    public EnvelopeGetSummaryFilterObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets envelope.
+     *
+     * @param envelope the envelope
+     */
+    public void setEnvelope(EnvelopeGetSummaryFilterObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets envelope signature.
+     *
+     * @return the envelope signature
+     */
+    @Override
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets envelope signature.
+     *
+     * @param digitalSignature the envelope signature
+     */
+    @Override
+    public void setEnvelopeSignature(String digitalSignature) {
+        this.envelopeSignature = digitalSignature;
+    }
+}

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/EnvelopeGetSummaryFilterObjectTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvelopeGetSummaryFilterObjectTest {
+
+    // Class Variables
+    private EnvelopeGetSummaryFilterObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Generate a new object
+        this.obj = new EnvelopeGetSummaryFilterObject();
+        this.obj.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.obj.setDataProductType(SECOM_DataProductType.S101);
+        this.obj.setProductVersion("version");
+        this.obj.setGeometry("geometry");
+        this.obj.setUnlocode("unlocode");
+        this.obj.setValidFrom(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.obj.setValidTo(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.obj.setPage(1);
+        this.obj.setPageSize(100);
+        this.obj.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.obj.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.obj.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        EnvelopeGetSummaryFilterObject result = this.mapper.readValue(jsonString, EnvelopeGetSummaryFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertEquals(this.obj.getContainerType(), result.getContainerType());
+        assertEquals(this.obj.getDataProductType(), result.getDataProductType());
+        assertEquals(this.obj.getProductVersion(), result.getProductVersion());
+        assertEquals(this.obj.getGeometry(), result.getGeometry());
+        assertEquals(this.obj.getUnlocode(), result.getUnlocode());
+        assertEquals(this.obj.getValidFrom(), result.getValidFrom());
+        assertEquals(this.obj.getValidTo(), result.getValidTo());
+        assertEquals(this.obj.getPage(), result.getPage());
+        assertEquals(this.obj.getPageSize(), result.getPageSize());
+        assertArrayEquals(this.obj.getEnvelopeSignatureCertificate(), result.getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), result.getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelopeSignatureTime(), result.getEnvelopeSignatureTime());
+    }
+
+    /**
+     * Test that we can correctly generate the SECOM signature CSV.
+     */
+    @Test
+    void testGetCsvString() {
+        // Generate the signature CSV
+        String signatureCSV = this.obj.getCsvString();
+
+        // Match the individual entries of the string
+        String[] csv = signatureCSV.split("\\.");
+        assertEquals(String.valueOf(this.obj.getContainerType().getValue()), csv[0]);
+        assertEquals(this.obj.getDataProductType().getValue(), csv[1]);
+        assertEquals(this.obj.getProductVersion(), csv[2]);
+        assertEquals(this.obj.getGeometry(), csv[3]);
+        assertEquals(this.obj.getUnlocode(), csv[4]);
+        assertEquals(String.valueOf(this.obj.getValidFrom().getEpochSecond()), csv[5]);
+        assertEquals(String.valueOf(this.obj.getValidTo().getEpochSecond()), csv[6]);
+        assertEquals(String.valueOf(this.obj.getPage()), csv[7]);
+        assertEquals(String.valueOf(this.obj.getPageSize()), csv[8]);
+        assertEquals(Arrays.toString(this.obj.getEnvelopeSignatureCertificate()), csv[9]);
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), csv[10]);
+        assertEquals(String.valueOf(this.obj.getEnvelopeSignatureTime().getEpochSecond()), csv[11]);
+    }
+
+}

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetSummaryFilterObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetSummaryFilterObjectTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetSummaryFilterObjectTest {
+
+    // Class Variables
+    private EnvelopeGetSummaryFilterObject envelopeGetSummaryFilterObject;
+    private GetSummaryFilterObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a new envelope get summary filter object
+        this.envelopeGetSummaryFilterObject = new EnvelopeGetSummaryFilterObject();
+        this.envelopeGetSummaryFilterObject.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.envelopeGetSummaryFilterObject.setDataProductType(SECOM_DataProductType.S101);
+        this.envelopeGetSummaryFilterObject.setProductVersion("version");
+        this.envelopeGetSummaryFilterObject.setGeometry("geometry");
+        this.envelopeGetSummaryFilterObject.setUnlocode("unlocode");
+        this.envelopeGetSummaryFilterObject.setValidFrom(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.envelopeGetSummaryFilterObject.setValidTo(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        this.envelopeGetSummaryFilterObject.setPage(1);
+        this.envelopeGetSummaryFilterObject.setPageSize(100);
+        this.envelopeGetSummaryFilterObject.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.envelopeGetSummaryFilterObject.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.envelopeGetSummaryFilterObject.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // Generate a new object
+        this.obj = new GetSummaryFilterObject();
+        this.obj.setEnvelope(this.envelopeGetSummaryFilterObject);
+        this.obj.setEnvelopeSignature("envelopeSignature");
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetSummaryFilterObject result = this.mapper.readValue(jsonString, GetSummaryFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertNotNull(result.getEnvelope());
+        assertEquals(this.obj.getEnvelope().getContainerType(), result.getEnvelope().getContainerType());
+        assertEquals(this.obj.getEnvelope().getDataProductType(), result.getEnvelope().getDataProductType());
+        assertEquals(this.obj.getEnvelope().getProductVersion(), result.getEnvelope().getProductVersion());
+        assertEquals(this.obj.getEnvelope().getGeometry(), result.getEnvelope().getGeometry());
+        assertEquals(this.obj.getEnvelope().getUnlocode(), result.getEnvelope().getUnlocode());
+        assertEquals(this.obj.getEnvelope().getValidFrom(), result.getEnvelope().getValidFrom());
+        assertEquals(this.obj.getEnvelope().getValidTo(), result.getEnvelope().getValidTo());
+        assertEquals(this.obj.getEnvelope().getPage(), result.getEnvelope().getPage());
+        assertEquals(this.obj.getEnvelope().getPageSize(), result.getEnvelope().getPageSize());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertEquals(this.obj.getEnvelopeSignature(), result.getEnvelopeSignature());
+    }
+
+}

--- a/secom-v2-springboot2/src/main/java/org/grad/secomv2/springboot2/components/SecomClient.java
+++ b/secom-v2-springboot2/src/main/java/org/grad/secomv2/springboot2/components/SecomClient.java
@@ -62,6 +62,7 @@ import static org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface.ENC
 import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetSummaryServiceInterface.POST_GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.RemoveSubscriptionServiceInterface.REMOVE_SUBSCRIPTION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
@@ -474,6 +475,27 @@ public class SecomClient {
                     return builder.build();
                 })
                 .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(GetSummaryResponseObject.class)
+                .blockOptional();
+    }
+
+    /**
+     * POST /v2/object/search/summary : A list of information shall be returned
+     * from this interface. The summary contains identity, status and short
+     * description of each information object. The actual information object
+     * shall be retrieved using the Get interface.
+     *
+     * @param getSummaryFilterObject the get summary filter object
+     * @return the summary response object
+     */
+    public Optional<GetSummaryResponseObject> postGetSummary(GetSummaryFilterObject getSummaryFilterObject) {
+        return this.secomClient
+                .post()
+                .uri(POST_GET_SUMMARY_INTERFACE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(getSummaryFilterObject))
                 .retrieve()
                 .bodyToMono(GetSummaryResponseObject.class)
                 .blockOptional();

--- a/secom-v2-springboot3/src/main/java/org/grad/secomv2/springboot3/components/SecomClient.java
+++ b/secom-v2-springboot3/src/main/java/org/grad/secomv2/springboot3/components/SecomClient.java
@@ -62,6 +62,7 @@ import static org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface.ENC
 import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetSummaryServiceInterface.POST_GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.RemoveSubscriptionServiceInterface.REMOVE_SUBSCRIPTION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
@@ -474,6 +475,27 @@ public class SecomClient {
                     return builder.build();
                 })
                 .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(GetSummaryResponseObject.class)
+                .blockOptional();
+    }
+
+    /**
+     * POST /v2/object/search/summary : A list of information shall be returned
+     * from this interface. The summary contains identity, status and short
+     * description of each information object. The actual information object
+     * shall be retrieved using the Get interface.
+     *
+     * @param getSummaryFilterObject the get summary filter object
+     * @return the summary response object
+     */
+    public Optional<GetSummaryResponseObject> postGetSummary(GetSummaryFilterObject getSummaryFilterObject) {
+        return this.secomClient
+                .post()
+                .uri(POST_GET_SUMMARY_INTERFACE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(getSummaryFilterObject))
                 .retrieve()
                 .bodyToMono(GetSummaryResponseObject.class)
                 .blockOptional();


### PR DESCRIPTION
This is Changyun Lee from Aivenautics. I heard from Oliver that contributions here are welcome, so I've taken a first pass at some of the key parts in advance, although I'm not sure yet how the final draft will turn out..

It is the first of a series of PRs to add POST support for the Get, Get Summary, and Get By Link interfaces as specified in 80/1186/CD (SECOM CD3). This PR covers the Get Summary part.

### Summary

- Add POST /v2/object/search/summary endpoint as specified in CD3 Table 36
- Add EnvelopeGetSummaryFilterObject and GetSummaryFilterObject models (CD3 Table 33)
- Add PostGetSummaryServiceInterface with HTTP 422 handling (CD3 Table 37)
- Add POST_GET_SUMMARY_INTERFACE_PATH to SecomSignatureFilter for envelope signature verification on incoming POST requests
- Add POST_GET_SUMMARY_INTERFACE_PATH to SecomV2ExceptionMapper for routing exceptions to the correct handler
- Add postGetSummary() client method in SecomClient
- All changes applied to both javax and jakarta modules
- Tests for both model classes (JSON serialization + CSV signature generation)


### Design decision

One thing that wasn't clear was whether to replace the existing GET endpoints with POST, just add the POST method to the existing interface, or add POST as a separate interface. Since the CD3 document keeps the GET REST implementation (GET /object/summary) and adds POST (POST /object/search/summary) alongside it, a separate interface (PostGetSummaryServiceInterface) was added rather than modifying the existing one — because that would likely require changes for services already implementing it. 

Any feedback on this approach would be appreciated.