### PR TITLE
Add POST-based Get Interface (/v2/object/search) as specified in SECOM CD3

### DIFF
--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
@@ -129,6 +129,10 @@ public class SecomSignatureFilter implements ContainerRequestFilter {
             else if (rqstCtx.getUriInfo().getPath().endsWith(SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH)){
                 obj = this.parseRequestBody(rqstCtx, SearchFilterObject.class);
             }
+            // For the POST Get Interface Requests
+            else if (rqstCtx.getUriInfo().getPath().endsWith(PostGetServiceInterface.POST_GET_INTERFACE_PATH)) {
+                obj = this.parseRequestBody(rqstCtx, GetFilterObject.class);
+            }
         }
 
         // If we have an object, validate the signatures

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -35,6 +35,7 @@ import static org.grad.secomv2.core.interfaces.AccessNotificationServiceInterfac
 import static org.grad.secomv2.core.interfaces.AccessServiceInterface.ACCESS_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.AcknowledgementServiceInterface.ACKNOWLEDGMENT_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.CapabilityServiceInterface.CAPABILITY_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetServiceInterface.POST_GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.EncryptionKeyNotifyServiceInterface.ENCRYPTION_KEY_NOTIFY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface.ENCRYPTION_KEY_INTERFACE_PATH;
@@ -146,6 +147,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     } else if(Objects.equals(this.request.getMethod(), "POST")) {
                         return UploadServiceInterface.handleUploadInterfaceExceptions(ex, this.request, null);
                     }
+                case POST_GET_INTERFACE_PATH:
+                    return PostGetServiceInterface.handleGerInterfaceException(ex, this.request, null);
                 case GET_SUMMARY_INTERFACE_PATH:
                     return GetSummaryServiceInterface.handleGetSummaryInterfaceExceptions(ex, this.request, null);
                 case PING_INTERFACE_PATH:

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.GetFilterObject;
+import org.grad.secomv2.core.models.GetResponseObject;
+
+/**
+ * The SECOM Get Interface Definition.
+ * </p>
+ * This interface definition can be used by the SECOM-compliant services in
+ * order to direct the implementation of the relevant endpoint according to
+ * the specified SECOM standard version.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public interface PostGetServiceInterface extends GenericSecomInterface{
+    /**
+     * The Interface Endpoint Path.
+     */
+    String POST_GET_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/object/search";
+
+    /**
+     * POST /v2/object/search : The Get interface is used for pulling information from a
+     * service provider. The owner of the information (provider) is responsible
+     * for the authorization procedure before returning information.
+     *
+     * @param getFilterObject the get filter object
+     * @return the object information
+     */
+    @Path(POST_GET_INTERFACE_PATH)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    GetResponseObject get(@Valid GetFilterObject getFilterObject);
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleGerInterfaceException(Exception ex,
+                                                HttpServletRequest request,
+                                                HttpServletResponse response) {
+        // Create the get response
+        int responseStatusCode;
+        GetResponseObject getResponseObject = new GetResponseObject();
+
+        // Handle according to the exception type
+        if(ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatusCode = Response.Status.BAD_REQUEST.getStatusCode();
+        } else if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException) {
+            // 422 (Unprocessable Entity) is used when the request is syntactically valid
+            // but cannot be processed due to domain-specific validation (SECOM rules).
+            // Note: 422 is not defined in jakarta.ws.rs.Response.Status, so it is set explicitly.
+            responseStatusCode = 422;
+        }
+        else if(ex instanceof SecomNotAuthorisedException) {
+            responseStatusCode = Response.Status.FORBIDDEN.getStatusCode();
+        } else if(ex instanceof SecomNotFoundException) {
+            responseStatusCode = Response.Status.NOT_FOUND.getStatusCode();
+        } else {
+            responseStatusCode = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
+        }
+
+        // And send the error response back
+        return Response.status(responseStatusCode)
+                .entity(getResponseObject)
+                .build();
+    }
+
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The SECOM Envelope Get Filter Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class EnvelopeGetFilterObject extends AbstractEnvelope {
+
+    // Class Variables
+    @NotNull
+    @Schema(description = "Reference to information object, e.g. from the Get Summary response")
+    private UUID dataReference;
+    @NotNull
+    private ContainerTypeEnum containerType;
+    @NotNull
+    @Schema(description = "Data product type name requested, e.g. S-124, S-421")
+    private SECOM_DataProductType dataProductType;
+    @NotNull
+    @Schema(description = "S-100 based Product type version requested, e.g. 1.0.0")
+    private String productVersion;
+    @NotNull
+    @Schema(type = "string", description = "Geometry condition for geolocated information objects", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
+    @Pattern(regexp = "^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$")
+    private String geometry;
+    @NotNull
+    @Schema(description = "Code of defined object", type = "string", example = "GBHRW")
+    @Pattern(regexp = "[A-Z]{5}")
+    private String unlocode;
+    @NotNull
+    @Schema(description = "Valid from time")
+    private Instant validFrom;
+    @NotNull
+    @Schema(description = "Valid until time")
+    private Instant validTo;
+    @NotNull
+    @Schema(description = "Requested pagination page")
+    private Integer page;
+    @NotNull
+    @Schema(description = "Requested pagination page size")
+    private Integer pageSize;
+
+    /**
+     * Get data reference.
+     *
+     * @return the data reference
+     */
+    public UUID getDataReference() {
+        return dataReference;
+    }
+
+    /**
+     * Sets data reference.
+     *
+     * @param dataReference the data reference
+     */
+    public void setDataReference(UUID dataReference) {
+        this.dataReference = dataReference;
+    }
+
+    /**
+     * Gets container type.
+     *
+     * @return the container type
+     */
+    public ContainerTypeEnum getContainerType() {
+        return containerType;
+    }
+
+    /**
+     * Sets container type.
+     *
+     * @param containerType the container type
+     */
+    public void setContainerType(ContainerTypeEnum containerType) {
+        this.containerType = containerType;
+    }
+
+    /**
+     * Gets data product type.
+     *
+     * @return the data product type
+     */
+    public SECOM_DataProductType getDataProductType() {
+        return dataProductType;
+    }
+
+    /**
+     * Sets data product type.
+     *
+     * @param dataProductType the data product type
+     */
+    public void setDataProductType(SECOM_DataProductType dataProductType) {
+        this.dataProductType = dataProductType;
+    }
+
+    /**
+     * Gets product version.
+     *
+     * @return the product version
+     */
+    public String getProductVersion() {
+        return productVersion;
+    }
+
+    /**
+     * Sets product version.
+     *
+     * @param productVersion the product version
+     */
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
+
+    /**
+     * Gets geometry
+     *
+     * @return the geometry
+     */
+    public String getGeometry() {
+        return geometry;
+    }
+
+    /**
+     * Sets geometry.
+     *
+     * @param geometry the geometry
+     */
+    public void setGeometry(String geometry) {
+        this.geometry = geometry;
+    }
+
+    /**
+     * Gets unlocode.
+     *
+     * @return the unlocode
+     */
+    public String getUnlocode() {
+        return unlocode;
+    }
+
+    /**
+     * Sets unlocode.
+     *
+     * @param unlocode the unlocode
+     */
+    public void setUnlocode(String unlocode) {
+        this.unlocode = unlocode;
+    }
+
+    /**
+     * Gets valid from.
+     *
+     * @return the valid from
+     */
+    public Instant getValidFrom() {
+        return validFrom;
+    }
+
+    /**
+     * Sets valid from.
+     *
+     * @param validFrom the valid from
+     */
+    public void setValidFrom(Instant validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    /**
+     * Gets valid to.
+     *
+     * @return the valid to
+     */
+    public Instant getValidTo() {
+        return validTo;
+    }
+
+    /**
+     * Sets valid to.
+     *
+     * @param validTo the valid to
+     */
+    public void setValidTo(Instant validTo) {
+        this.validTo = validTo;
+    }
+
+    /**
+     * Gets page.
+     *
+     * @return the page
+     */
+    public Integer getPage() {
+        return page;
+    }
+
+    /**
+     * Sets page.
+     *
+     * @param page the page
+     */
+    public void setPage(Integer page) {
+        this.page = page;
+    }
+
+    /**
+     * Gets page size.
+     *
+     * @return the page size
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets page size.
+     *
+     * @param pageSize the page size
+     */
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                dataReference,
+                containerType,
+                dataProductType,
+                productVersion,
+                geometry,
+                unlocode,
+                validFrom,
+                validTo,
+                page,
+                pageSize,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetFilterObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetFilterObject.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import jakarta.validation.constraints.NotNull;
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+/**
+ * The SECOM Get Filter Object Class
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+
+ */
+public class GetFilterObject implements EnvelopeSignatureBearer {
+
+    // Class Variables
+    @NotNull
+    private EnvelopeGetFilterObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Gets envelope.
+     *
+     * @return the envelope
+     */
+    @Override
+    public EnvelopeGetFilterObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets envelope.
+     *
+     * @param envelope the envelope
+     */
+    public void setEnvelope(EnvelopeGetFilterObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets envelope signature.
+     *
+     * @return the envelope signature
+     */
+    @Override
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets envelope signature.
+     *
+     * @param digitalSignature the envelope signature
+     */
+    @Override
+    public void setEnvelopeSignature(String digitalSignature) {
+        this.envelopeSignature = digitalSignature;
+    }
+}

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/EnvelopeGetFilterObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/EnvelopeGetFilterObjectTest.java
@@ -1,0 +1,106 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvelopeGetFilterObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetFilterObject obj;
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Generate a new object
+        this.obj = new EnvelopeGetFilterObject();
+        this.obj.setDataReference(UUID.randomUUID());
+        this.obj.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.obj.setDataProductType(SECOM_DataProductType.S101);
+        this.obj.setProductVersion("version");
+        this.obj.setGeometry("geometry");
+        this.obj.setUnlocode("unlocode");
+        this.obj.setValidFrom(Instant.now().minus(1, ChronoUnit.DAYS));
+        this.obj.setValidTo(Instant.now().plus(1, ChronoUnit.DAYS));
+        this.obj.setPage(0);
+        this.obj.setPageSize(10);
+        this.obj.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.obj.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.obj.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        EnvelopeGetFilterObject result = this.mapper.readValue(jsonString, EnvelopeGetFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertEquals(this.obj.getDataReference(), this.obj.getDataReference());
+        assertEquals(this.obj.getContainerType(), this.obj.getContainerType());
+        assertEquals(this.obj.getDataProductType(), result.getDataProductType());
+        assertEquals(this.obj.getProductVersion(), result.getProductVersion());
+        assertEquals(this.obj.getGeometry(), result.getGeometry());
+        assertEquals(this.obj.getUnlocode(), result.getUnlocode());
+        assertEquals(this.obj.getValidFrom(), result.getValidFrom());
+        assertEquals(this.obj.getValidTo(), result.getValidTo());
+        assertEquals(this.obj.getPage(), result.getPage());
+        assertEquals(this.obj.getPageSize(), result.getPageSize());
+        assertArrayEquals(this.obj.getEnvelopeSignatureCertificate(), result.getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), result.getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelopeSignatureTime(), result.getEnvelopeSignatureTime());
+    }
+
+    /**
+     * Test that we can correctly generate the SECOM signature CSV.
+     */
+    @Test
+    void testGetCsvString() {
+        // Generate the signature CSV
+        String signatureCSV = this.obj.getCsvString();
+
+        // Match the individual entries of the string
+        String[] csv = signatureCSV.split("\\.");
+        assertEquals(this.obj.getDataReference().toString(), csv[0]);
+        assertEquals(String.valueOf(this.obj.getContainerType().getValue()), csv[1]);
+        assertEquals(this.obj.getDataProductType().getValue(), csv[2]);
+        assertEquals(this.obj.getProductVersion(), csv[3]);
+        assertEquals(this.obj.getGeometry(), csv[4]);
+        assertEquals(this.obj.getUnlocode(), csv[5]);
+        assertEquals(String.valueOf(this.obj.getValidFrom().getEpochSecond()), csv[6]);
+        assertEquals(String.valueOf(this.obj.getValidTo().getEpochSecond()), csv[7]);
+        assertEquals(this.obj.getPage().toString(), csv[8]);
+        assertEquals(this.obj.getPageSize().toString(), csv[9]);
+        assertEquals(Arrays.toString(this.obj.getEnvelopeSignatureCertificate()), csv[10]);
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), csv[11]);
+        assertEquals(String.valueOf(this.obj.getEnvelopeSignatureTime().getEpochSecond()), csv[12]);
+    }
+}

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetFilterObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetFilterObjectTest.java
@@ -1,0 +1,92 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetFilterObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetFilterObject envelopeGetFilterObject;
+    private GetFilterObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Create a new envelope get filter object
+        this.envelopeGetFilterObject = new EnvelopeGetFilterObject();
+        this.envelopeGetFilterObject.setDataReference(UUID.randomUUID());
+        this.envelopeGetFilterObject.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.envelopeGetFilterObject.setDataProductType(SECOM_DataProductType.S101);
+        this.envelopeGetFilterObject.setProductVersion("version");
+        this.envelopeGetFilterObject.setGeometry("geometry");
+        this.envelopeGetFilterObject.setUnlocode("unlocode");
+        this.envelopeGetFilterObject.setValidFrom(Instant.now().minus(1, ChronoUnit.DAYS));
+        this.envelopeGetFilterObject.setValidTo(Instant.now().plus(1, ChronoUnit.DAYS));
+        this.envelopeGetFilterObject.setPage(0);
+        this.envelopeGetFilterObject.setPageSize(10);
+        this.envelopeGetFilterObject.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.envelopeGetFilterObject.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.envelopeGetFilterObject.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // Generate a new object
+        this.obj = new GetFilterObject();
+        this.obj.setEnvelope(this.envelopeGetFilterObject);
+        this.obj.setDigitalSignature("signature");
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetFilterObject result = this.mapper.readValue(jsonString, GetFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertNotNull(result.getEnvelope());
+        assertEquals(this.obj.getEnvelope().getDataReference(), result.getEnvelope().getDataReference());
+        assertEquals(this.obj.getEnvelope().getContainerType(), result.getEnvelope().getContainerType());
+        assertEquals(this.obj.getEnvelope().getDataProductType(), result.getEnvelope().getDataProductType());
+        assertEquals(this.obj.getEnvelope().getProductVersion(), result.getEnvelope().getProductVersion());
+        assertEquals(this.obj.getEnvelope().getGeometry(), result.getEnvelope().getGeometry());
+        assertEquals(this.obj.getEnvelope().getUnlocode(), result.getEnvelope().getUnlocode());
+        assertEquals(this.obj.getEnvelope().getValidFrom(), result.getEnvelope().getValidFrom());
+        assertEquals(this.obj.getEnvelope().getValidTo(), result.getEnvelope().getValidTo());
+        assertEquals(this.obj.getEnvelope().getPage(), result.getEnvelope().getPage());
+        assertEquals(this.obj.getEnvelope().getPageSize(), result.getEnvelope().getPageSize());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertEquals(this.obj.getEnvelopeSignature(), result.getEnvelopeSignature());
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
@@ -18,13 +18,10 @@ package org.grad.secomv2.core.components;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.grad.secomv2.core.base.*;
+import org.grad.secomv2.core.interfaces.*;
 import org.grad.secomv2.core.models.*;
 import org.grad.secomv2.core.exceptions.SecomInvalidCertificateException;
 import org.grad.secomv2.core.exceptions.SecomSignatureVerificationException;
-import org.grad.secomv2.core.interfaces.AcknowledgementServiceInterface;
-import org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface;
-import org.grad.secomv2.core.interfaces.UploadLinkServiceInterface;
-import org.grad.secomv2.core.interfaces.UploadServiceInterface;
 import org.grad.secomv2.core.models.enums.DigitalSignatureAlgorithmEnum;
 import org.grad.secomv2.core.utils.PkiUtils;
 import org.grad.secomv2.core.utils.SecomPemUtils;
@@ -127,6 +124,10 @@ public class SecomSignatureFilter implements ContainerRequestFilter {
             // For the Encryption Key Interface Requests
             else if (rqstCtx.getUriInfo().getPath().endsWith(EncryptionKeyServiceInterface.ENCRYPTION_KEY_INTERFACE_PATH)) {
                 obj = this.parseRequestBody(rqstCtx, EncryptionKeyRequestObject.class);
+            }
+            // For the POST Get Interface Requests
+            else if (rqstCtx.getUriInfo().getPath().endsWith(PostGetServiceInterface.POST_GET_INTERFACE_PATH)) {
+                obj = this.parseRequestBody(rqstCtx, GetFilterObject.class);
             }
         }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -41,6 +41,7 @@ import static org.grad.secomv2.core.interfaces.GetPublicKeyServiceInterface.GET_
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetServiceInterface.POST_GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionServiceInterface.SUBSCRIPTION_INTERFACE_PATH;
@@ -146,6 +147,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     } else if(Objects.equals(this.request.getMethod(), "POST")) {
                         return UploadServiceInterface.handleUploadInterfaceExceptions(ex, this.request, null);
                     }
+                case POST_GET_INTERFACE_PATH:
+                    return PostGetServiceInterface.handleGerInterfaceException(ex, this.request, null);
                 case GET_SUMMARY_INTERFACE_PATH:
                     return GetSummaryServiceInterface.handleGetSummaryInterfaceExceptions(ex, this.request, null);
                 case PING_INTERFACE_PATH:

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.GetFilterObject;
+import org.grad.secomv2.core.models.GetResponseObject;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * The SECOM Get Interface Definition.
+ * </p>
+ * This interface definition can be used by the SECOM-compliant services in
+ * order to direct the implementation of the relevant endpoint according to
+ * the specified SECOM standard version.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public interface PostGetServiceInterface extends GenericSecomInterface{
+    /**
+     * The Interface Endpoint Path.
+     */
+    String POST_GET_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/object/search";
+
+    /**
+     * POST /v2/object/search : The Get interface is used for pulling information from a
+     * service provider. The owner of the information (provider) is responsible
+     * for the authorization procedure before returning information.
+     *
+     * @param getFilterObject the get filter object
+     * @return the object information
+     */
+    @Path(POST_GET_INTERFACE_PATH)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    GetResponseObject get(@Valid GetFilterObject getFilterObject);
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleGerInterfaceException(Exception ex,
+                                                HttpServletRequest request,
+                                                HttpServletResponse response) {
+        // Create the get response
+        int responseStatusCode;
+        GetResponseObject getResponseObject = new GetResponseObject();
+
+        // Handle according to the exception type
+        if(ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatusCode = Response.Status.BAD_REQUEST.getStatusCode();
+        } else if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException) {
+            // 422 (Unprocessable Entity) is used when the request is syntactically valid
+            // but cannot be processed due to domain-specific validation (SECOM rules).
+            // Note: 422 is not defined in jakarta.ws.rs.Response.Status, so it is set explicitly.
+            responseStatusCode = 422;
+        }
+        else if(ex instanceof SecomNotAuthorisedException) {
+            responseStatusCode = Response.Status.FORBIDDEN.getStatusCode();
+        } else if(ex instanceof SecomNotFoundException) {
+            responseStatusCode = Response.Status.NOT_FOUND.getStatusCode();
+        } else {
+            responseStatusCode = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
+        }
+
+        // And send the error response back
+        return Response.status(responseStatusCode)
+                .entity(getResponseObject)
+                .build();
+    }
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The SECOM Envelope Get Filter Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class EnvelopeGetFilterObject extends AbstractEnvelope {
+
+    // Class Variables
+    @NotNull
+    @Schema(description = "Reference to information object, e.g. from the Get Summary response")
+    private UUID dataReference;
+    @NotNull
+    private ContainerTypeEnum containerType;
+    @NotNull
+    @Schema(description = "Data product type name requested, e.g. S-124, S-421")
+    private SECOM_DataProductType dataProductType;
+    @NotNull
+    @Schema(description = "S-100 based Product type version requested, e.g. 1.0.0")
+    private String productVersion;
+    @NotNull
+    @Schema(type = "string", description = "Geometry condition for geolocated information objects", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
+    @Pattern(regexp = "^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$")
+    private String geometry;
+    @NotNull
+    @Schema(description = "Code of defined object", type = "string", example = "GBHRW")
+    @Pattern(regexp = "[A-Z]{5}")
+    private String unlocode;
+    @NotNull
+    @Schema(description = "Valid from time")
+    private Instant validFrom;
+    @NotNull
+    @Schema(description = "Valid until time")
+    private Instant validTo;
+    @NotNull
+    @Schema(description = "Requested pagination page")
+    private Integer page;
+    @NotNull
+    @Schema(description = "Requested pagination page size")
+    private Integer pageSize;
+
+    /**
+     * Get data reference.
+     *
+     * @return the data reference
+     */
+    public UUID getDataReference() {
+        return dataReference;
+    }
+
+    /**
+     * Sets data reference.
+     *
+     * @param dataReference the data reference
+     */
+    public void setDataReference(UUID dataReference) {
+        this.dataReference = dataReference;
+    }
+
+    /**
+     * Gets container type.
+     *
+     * @return the container type
+     */
+    public ContainerTypeEnum getContainerType() {
+        return containerType;
+    }
+
+    /**
+     * Sets container type.
+     *
+     * @param containerType the container type
+     */
+    public void setContainerType(ContainerTypeEnum containerType) {
+        this.containerType = containerType;
+    }
+
+    /**
+     * Gets data product type.
+     *
+     * @return the data product type
+     */
+    public SECOM_DataProductType getDataProductType() {
+        return dataProductType;
+    }
+
+    /**
+     * Sets data product type.
+     *
+     * @param dataProductType the data product type
+     */
+    public void setDataProductType(SECOM_DataProductType dataProductType) {
+        this.dataProductType = dataProductType;
+    }
+
+    /**
+     * Gets product version.
+     *
+     * @return the product version
+     */
+    public String getProductVersion() {
+        return productVersion;
+    }
+
+    /**
+     * Sets product version.
+     *
+     * @param productVersion the product version
+     */
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
+
+    /**
+     * Gets geometry
+     *
+     * @return the geometry
+     */
+    public String getGeometry() {
+        return geometry;
+    }
+
+    /**
+     * Sets geometry.
+     *
+     * @param geometry the geometry
+     */
+    public void setGeometry(String geometry) {
+        this.geometry = geometry;
+    }
+
+    /**
+     * Gets unlocode.
+     *
+     * @return the unlocode
+     */
+    public String getUnlocode() {
+        return unlocode;
+    }
+
+    /**
+     * Sets unlocode.
+     *
+     * @param unlocode the unlocode
+     */
+    public void setUnlocode(String unlocode) {
+        this.unlocode = unlocode;
+    }
+
+    /**
+     * Gets valid from.
+     *
+     * @return the valid from
+     */
+    public Instant getValidFrom() {
+        return validFrom;
+    }
+
+    /**
+     * Sets valid from.
+     *
+     * @param validFrom the valid from
+     */
+    public void setValidFrom(Instant validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    /**
+     * Gets valid to.
+     *
+     * @return the valid to
+     */
+    public Instant getValidTo() {
+        return validTo;
+    }
+
+    /**
+     * Sets valid to.
+     *
+     * @param validTo the valid to
+     */
+    public void setValidTo(Instant validTo) {
+        this.validTo = validTo;
+    }
+
+    /**
+     * Gets page.
+     *
+     * @return the page
+     */
+    public Integer getPage() {
+        return page;
+    }
+
+    /**
+     * Sets page.
+     *
+     * @param page the page
+     */
+    public void setPage(Integer page) {
+        this.page = page;
+    }
+
+    /**
+     * Gets page size.
+     *
+     * @return the page size
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets page size.
+     *
+     * @param pageSize the page size
+     */
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                dataReference,
+                containerType,
+                dataProductType,
+                productVersion,
+                geometry,
+                unlocode,
+                validFrom,
+                validTo,
+                page,
+                pageSize,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetFilterObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetFilterObject.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * The SECOM Get Filter Object Class
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+
+ */
+public class GetFilterObject implements EnvelopeSignatureBearer {
+
+    // Class Variables
+    @NotNull
+    private EnvelopeGetFilterObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Gets envelope.
+     *
+     * @return the envelope
+     */
+    @Override
+    public EnvelopeGetFilterObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets envelope.
+     *
+     * @param envelope the envelope
+     */
+    public void setEnvelope(EnvelopeGetFilterObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets envelope signature.
+     *
+     * @return the envelope signature
+     */
+    @Override
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets envelope signature.
+     *
+     * @param digitalSignature the envelope signature
+     */
+    @Override
+    public void setEnvelopeSignature(String digitalSignature) {
+        this.envelopeSignature = digitalSignature;
+    }
+}

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/EnvelopeGetFilterObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/EnvelopeGetFilterObjectTest.java
@@ -1,0 +1,106 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvelopeGetFilterObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetFilterObject obj;
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Generate a new object
+        this.obj = new EnvelopeGetFilterObject();
+        this.obj.setDataReference(UUID.randomUUID());
+        this.obj.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.obj.setDataProductType(SECOM_DataProductType.S101);
+        this.obj.setProductVersion("version");
+        this.obj.setGeometry("geometry");
+        this.obj.setUnlocode("unlocode");
+        this.obj.setValidFrom(Instant.now().minus(1, ChronoUnit.DAYS));
+        this.obj.setValidTo(Instant.now().plus(1, ChronoUnit.DAYS));
+        this.obj.setPage(0);
+        this.obj.setPageSize(10);
+        this.obj.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.obj.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.obj.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        EnvelopeGetFilterObject result = this.mapper.readValue(jsonString, EnvelopeGetFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertEquals(this.obj.getDataReference(), this.obj.getDataReference());
+        assertEquals(this.obj.getContainerType(), this.obj.getContainerType());
+        assertEquals(this.obj.getDataProductType(), result.getDataProductType());
+        assertEquals(this.obj.getProductVersion(), result.getProductVersion());
+        assertEquals(this.obj.getGeometry(), result.getGeometry());
+        assertEquals(this.obj.getUnlocode(), result.getUnlocode());
+        assertEquals(this.obj.getValidFrom(), result.getValidFrom());
+        assertEquals(this.obj.getValidTo(), result.getValidTo());
+        assertEquals(this.obj.getPage(), result.getPage());
+        assertEquals(this.obj.getPageSize(), result.getPageSize());
+        assertArrayEquals(this.obj.getEnvelopeSignatureCertificate(), result.getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), result.getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelopeSignatureTime(), result.getEnvelopeSignatureTime());
+    }
+
+    /**
+     * Test that we can correctly generate the SECOM signature CSV.
+     */
+    @Test
+    void testGetCsvString() {
+        // Generate the signature CSV
+        String signatureCSV = this.obj.getCsvString();
+
+        // Match the individual entries of the string
+        String[] csv = signatureCSV.split("\\.");
+        assertEquals(this.obj.getDataReference().toString(), csv[0]);
+        assertEquals(String.valueOf(this.obj.getContainerType().getValue()), csv[1]);
+        assertEquals(this.obj.getDataProductType().getValue(), csv[2]);
+        assertEquals(this.obj.getProductVersion(), csv[3]);
+        assertEquals(this.obj.getGeometry(), csv[4]);
+        assertEquals(this.obj.getUnlocode(), csv[5]);
+        assertEquals(String.valueOf(this.obj.getValidFrom().getEpochSecond()), csv[6]);
+        assertEquals(String.valueOf(this.obj.getValidTo().getEpochSecond()), csv[7]);
+        assertEquals(this.obj.getPage().toString(), csv[8]);
+        assertEquals(this.obj.getPageSize().toString(), csv[9]);
+        assertEquals(Arrays.toString(this.obj.getEnvelopeSignatureCertificate()), csv[10]);
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), csv[11]);
+        assertEquals(String.valueOf(this.obj.getEnvelopeSignatureTime().getEpochSecond()), csv[12]);
+    }
+}

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetFilterObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetFilterObjectTest.java
@@ -1,0 +1,92 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
+import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetFilterObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetFilterObject envelopeGetFilterObject;
+    private GetFilterObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Setup an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Create a new envelope get filter object
+        this.envelopeGetFilterObject = new EnvelopeGetFilterObject();
+        this.envelopeGetFilterObject.setDataReference(UUID.randomUUID());
+        this.envelopeGetFilterObject.setContainerType(ContainerTypeEnum.S100_DataSet);
+        this.envelopeGetFilterObject.setDataProductType(SECOM_DataProductType.S101);
+        this.envelopeGetFilterObject.setProductVersion("version");
+        this.envelopeGetFilterObject.setGeometry("geometry");
+        this.envelopeGetFilterObject.setUnlocode("unlocode");
+        this.envelopeGetFilterObject.setValidFrom(Instant.now().minus(1, ChronoUnit.DAYS));
+        this.envelopeGetFilterObject.setValidTo(Instant.now().plus(1, ChronoUnit.DAYS));
+        this.envelopeGetFilterObject.setPage(0);
+        this.envelopeGetFilterObject.setPageSize(10);
+        this.envelopeGetFilterObject.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.envelopeGetFilterObject.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.envelopeGetFilterObject.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // Generate a new object
+        this.obj = new GetFilterObject();
+        this.obj.setEnvelope(this.envelopeGetFilterObject);
+        this.obj.setDigitalSignature("signature");
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetFilterObject result = this.mapper.readValue(jsonString, GetFilterObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertNotNull(result.getEnvelope());
+        assertEquals(this.obj.getEnvelope().getDataReference(), result.getEnvelope().getDataReference());
+        assertEquals(this.obj.getEnvelope().getContainerType(), result.getEnvelope().getContainerType());
+        assertEquals(this.obj.getEnvelope().getDataProductType(), result.getEnvelope().getDataProductType());
+        assertEquals(this.obj.getEnvelope().getProductVersion(), result.getEnvelope().getProductVersion());
+        assertEquals(this.obj.getEnvelope().getGeometry(), result.getEnvelope().getGeometry());
+        assertEquals(this.obj.getEnvelope().getUnlocode(), result.getEnvelope().getUnlocode());
+        assertEquals(this.obj.getEnvelope().getValidFrom(), result.getEnvelope().getValidFrom());
+        assertEquals(this.obj.getEnvelope().getValidTo(), result.getEnvelope().getValidTo());
+        assertEquals(this.obj.getEnvelope().getPage(), result.getEnvelope().getPage());
+        assertEquals(this.obj.getEnvelope().getPageSize(), result.getEnvelope().getPageSize());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertEquals(this.obj.getEnvelopeSignature(), result.getEnvelopeSignature());
+    }
+}

--- a/secom-v2-springboot2/src/main/java/org/grad/secomv2/springboot2/components/SecomClient.java
+++ b/secom-v2-springboot2/src/main/java/org/grad/secomv2/springboot2/components/SecomClient.java
@@ -63,6 +63,7 @@ import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetServiceInterface.POST_GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.RemoveSubscriptionServiceInterface.REMOVE_SUBSCRIPTION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
@@ -430,6 +431,28 @@ public class SecomClient {
                 .map(response -> response.decompressData(this.compressionProvider))
                 .map(response -> response.decryptData(this.encryptionProvider))
                 .map(GetResponseObject.class::cast);
+    }
+
+    /**
+     * POST /v2/object/search : The Post Get interface is used for pulling information from a
+     * service provider using a POST request. The owner of the information (provider) is responsible
+     * for the authorization procedure before returning information.
+     *
+     * @param getFilterObject  the get filter object
+     * @return the get response object
+     */
+    public Optional<GetResponseObject> postGet(GetFilterObject getFilterObject) {
+        //Prepare the upload envelope if valid
+        final EnvelopeGetFilterObject envelope = getFilterObject.getEnvelope();
+        return this.secomClient
+                .post()
+                .uri(POST_GET_INTERFACE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(getFilterObject))
+                .retrieve()
+                .bodyToMono(GetResponseObject.class)
+                .blockOptional();
     }
 
     /**

--- a/secom-v2-springboot3/src/main/java/org/grad/secomv2/springboot3/components/SecomClient.java
+++ b/secom-v2-springboot3/src/main/java/org/grad/secomv2/springboot3/components/SecomClient.java
@@ -63,6 +63,7 @@ import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetServiceInterface.POST_GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.RemoveSubscriptionServiceInterface.REMOVE_SUBSCRIPTION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
@@ -430,6 +431,28 @@ public class SecomClient {
                 .map(response -> response.decompressData(this.compressionProvider))
                 .map(response -> response.decryptData(this.encryptionProvider))
                 .map(GetResponseObject.class::cast);
+    }
+
+    /**
+     * POST /v2/object/search : The Post Get interface is used for pulling information from a
+     * service provider using a POST request. The owner of the information (provider) is responsible
+     * for the authorization procedure before returning information.
+     *
+     * @param getFilterObject  the get filter object
+     * @return the get response object
+     */
+    public Optional<GetResponseObject> postGet(GetFilterObject getFilterObject) {
+        //Prepare the upload envelope if valid
+        final EnvelopeGetFilterObject envelope = getFilterObject.getEnvelope();
+        return this.secomClient
+                .post()
+                .uri(POST_GET_INTERFACE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(getFilterObject))
+                .retrieve()
+                .bodyToMono(GetResponseObject.class)
+                .blockOptional();
     }
 
     /**


### PR DESCRIPTION
Hello, this is Junyeon from AIVeNautics in Korea.
We are preparing for integration testing from the SECOM Service Provider to the End User, and the SECOM Version 2 release is required for this.
To help move this forward, I have created this PR.
I would greatly appreciate any feedback.
Thank you!

# Summary
Add POST-based Get Interface (/v2/object/search) as specified in SECOM CD3

# Changes
- Introduce PostGetServiceInterface to support POST-based Get Interface
  - Add POST /v2/object/search endpoint as defined in SECOM CD3
- Add GetFilterObject and EnvelopeGetFilterObject
  - Represent input data for the Get Interface (Table 28)
- Update SecomSignatureFilter
  - Add POST_GET_INTERFACE_PATH for envelope signature verification of POST requests
- Update SecomV2ExceptionMapper
  - Add POST_GET_INTERFACE_PATH for proper exception routing
- Extend SecomClient
  - Add postGet() method for POST-based Get requests
- Apply all changes to both javax and jakarta modules
- Add tests
  - JSON serialization tests for model classes
  - CSV signature generation tests
  
  # Comment
I have a question regarding the SECOM v2 specification.

It is not entirely clear whether the POST-based Get interface is intended to replace the existing GET-based interface, or if it is meant to be provided as an additional option.

For now, I have implemented it as a separate interface (POST-based) alongside the existing GET interface.

Please let me know your thoughts on this approach.