### PR TITLE
Add POST-based Get By Link Interface (/v2/object/search/link) as specified in SECOM CD3

### DIFF
--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
@@ -129,6 +129,10 @@ public class SecomSignatureFilter implements ContainerRequestFilter {
             else if (rqstCtx.getUriInfo().getPath().endsWith(SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH)){
                 obj = this.parseRequestBody(rqstCtx, SearchFilterObject.class);
             }
+            // For the POST Get By Link Interface Requests
+            else if (rqstCtx.getUriInfo().getPath().endsWith(PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH)){
+                obj = this.parseRequestBody(rqstCtx, GetByLinkObject.class);
+            }
         }
 
         // If we have an object, validate the signatures

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -35,6 +35,7 @@ import static org.grad.secomv2.core.interfaces.AccessNotificationServiceInterfac
 import static org.grad.secomv2.core.interfaces.AccessServiceInterface.ACCESS_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.AcknowledgementServiceInterface.ACKNOWLEDGMENT_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.CapabilityServiceInterface.CAPABILITY_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.EncryptionKeyNotifyServiceInterface.ENCRYPTION_KEY_NOTIFY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface.ENCRYPTION_KEY_INTERFACE_PATH;
@@ -140,6 +141,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     } else if(Objects.equals(this.request.getMethod(), "POST")) {
                         return UploadLinkServiceInterface.handleUploadLinkInterfaceExceptions(ex, this.request, null);
                     }
+                case POST_GET_BY_LINK_INTERFACE_PATH:
+                    return PostGetByLinkServiceInterface.handleGetByLinkInterfaceExceptions(ex, this.request, null);
                 case GET_INTERFACE_PATH: // Also for upload
                     if(Objects.equals(this.request.getMethod(), "GET")) {
                         return GetServiceInterface.handleGetInterfaceExceptions(ex, this.request, null);

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomInvalidCertificateException;
+import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.GetByLinkObject;
+import org.grad.secomv2.core.models.GetByLinkResponseObject;
+
+public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
+    /**
+     * The Interface Endpoint Path.
+     */
+    String POST_GET_BY_LINK_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/object/search/link";
+
+    /**
+     * POST /v2/object/search/link : The POST Get By Link interface is used for pulling
+     * information from a data storage handled by the information owner. The
+     * link to the data storage can be exchanged with Upload Link interface.
+     * The owner of the information (provider) is responsible for relevant
+     * authentication and authorization procedure before returning information.
+     *
+     * @param getByLinkObject the get by link object
+     * @return get by link response object
+     */
+    @Path(POST_GET_BY_LINK_INTERFACE_PATH)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    GetByLinkResponseObject getByLink(@Valid GetByLinkObject getByLinkObject);
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleGetByLinkInterfaceExceptions(Exception ex,
+                                                       HttpServletRequest request,
+                                                       HttpServletResponse response) {
+        // Create the get by link response
+        Response.Status responseStatus = null;
+        String responseText = null;
+
+        // Handle according to the exception type
+        if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException
+                || ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatus = Response.Status.BAD_REQUEST;
+            responseText = "Bad Request";
+        } else if(ex instanceof SecomNotAuthorisedException) {
+            responseStatus = Response.Status.FORBIDDEN;
+            responseText = "Not authorized to requested information";
+        } else if(ex instanceof SecomInvalidCertificateException) {
+            responseStatus = Response.Status.FORBIDDEN;
+            responseText = "Invalid Certificate";
+        }  else if(ex instanceof SecomNotFoundException) {
+            responseStatus = Response.Status.NOT_FOUND;
+            responseText = String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier());
+        } else {
+            responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
+            responseText = responseStatus.getReasonPhrase();
+        }
+
+        // And send the error response back
+        return Response.status(responseStatus)
+                .entity(responseText)
+                .build();
+    }
+
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObject.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+/**
+ * The SECOM Envelope Get By Link Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class EnvelopeGetByLinkObject extends AbstractEnvelope {
+    // Class Variables
+    @NotNull
+    @Schema(description = "Identifier uploaded in Upload Link")
+    private UUID transactionIdentifier;
+
+
+    /**
+     * Get transaction identifier.
+     *
+     * @return the transaction identifier
+     */
+    public UUID getTransactionIdentifier() {
+        return transactionIdentifier;
+    }
+
+    /**
+     * Sets transaction identifier.
+     *
+     * @param transactionIdentifier the transaction identifier
+     */
+    public void setTransactionIdentifier(UUID transactionIdentifier) {
+        this.transactionIdentifier = transactionIdentifier;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                transactionIdentifier,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetByLinkObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetByLinkObject.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import jakarta.validation.constraints.NotNull;
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+/**
+ * The SECOM Get By Link Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class GetByLinkObject implements EnvelopeSignatureBearer {
+    // Class Variables
+    @NotNull
+    private EnvelopeGetByLinkObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Gets envelope.
+     *
+     * @return the envelope
+     */
+    @Override
+    public EnvelopeGetByLinkObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets envelope.
+     *
+     * @param envelope the envelope
+     */
+    public void setEnvelope(EnvelopeGetByLinkObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets envelope signature.
+     *
+     * @return the envelope signature
+     */
+    @Override
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets envelope signature.
+     *
+     * @param digitalSignature the envelope signature
+     */
+    @Override
+    public void setEnvelopeSignature(String digitalSignature) {
+        this.envelopeSignature = digitalSignature;
+    }
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetByLinkResponseObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/GetByLinkResponseObject.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * The SECOM Get By Link Response Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class GetByLinkResponseObject {
+    // Class Variables
+    @Schema(description = "Data as Base64 encoded binary format")
+    @NotNull
+    private byte[] data;
+
+    /**
+     * Gets data.
+     *
+     * @return the data
+     */
+    public byte[] getData() {
+        return data;
+    }
+
+    /**
+     * Sets data.
+     *
+     * @param data the data
+     */
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+}

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObjectTest.java
@@ -1,0 +1,78 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvelopeGetByLinkObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetByLinkObject obj;
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Set up an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Generate a new object
+        this.obj = new EnvelopeGetByLinkObject();
+        this.obj.setTransactionIdentifier(UUID.randomUUID());
+
+        this.obj.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.obj.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.obj.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        EnvelopeGetByLinkObject result = this.mapper.readValue(jsonString, EnvelopeGetByLinkObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertEquals(this.obj.getTransactionIdentifier(), result.getTransactionIdentifier());
+        assertArrayEquals(this.obj.getEnvelopeSignatureCertificate(), result.getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), result.getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelopeSignatureTime(), result.getEnvelopeSignatureTime());
+    }
+
+    /**
+     * Test that we can correctly generate the SECOM signature CSV.
+     */
+    @Test
+    void testGetCsvString() {
+        // Generate the signature CSV
+        String signatureCSV = this.obj.getCsvString();
+
+        // Match the individual entries of the string
+        String[] csv = signatureCSV.split("\\.");
+        assertEquals(this.obj.getTransactionIdentifier().toString(), csv[0]);
+        assertEquals(Arrays.toString(this.obj.getEnvelopeSignatureCertificate()), csv[1]);
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), csv[2]);
+        assertEquals(String.valueOf(this.obj.getEnvelopeSignatureTime().getEpochSecond()), csv[3]);
+    }
+}

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetByLinkObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetByLinkObjectTest.java
@@ -1,0 +1,70 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetByLinkObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetByLinkObject envelopeGetByLinkObject;
+    private GetByLinkObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Set up an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Create a new envelope get filter object
+        this.envelopeGetByLinkObject = new EnvelopeGetByLinkObject();
+        this.envelopeGetByLinkObject.setTransactionIdentifier(UUID.randomUUID());
+        this.envelopeGetByLinkObject.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.envelopeGetByLinkObject.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.envelopeGetByLinkObject.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // Generate a new object
+        this.obj = new GetByLinkObject();
+        this.obj.setEnvelope(this.envelopeGetByLinkObject);
+        this.obj.setDigitalSignature("signature");
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetByLinkObject result = this.mapper.readValue(jsonString, GetByLinkObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertNotNull(result.getEnvelope());
+        assertEquals(this.obj.getEnvelope().getTransactionIdentifier(), result.getEnvelope().getTransactionIdentifier());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertEquals(this.obj.getEnvelopeSignature(), result.getEnvelopeSignature());
+    }
+
+}

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetByLinkResponseObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/GetByLinkResponseObjectTest.java
@@ -1,0 +1,44 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetByLinkResponseObjectTest {
+    // Class Variables
+    private GetByLinkResponseObject obj;
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Set up an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Generate a new object
+        this.obj = new GetByLinkResponseObject();
+        this.obj.setData(new byte[0]);
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetByLinkResponseObject result = this.mapper.readValue(jsonString, GetByLinkResponseObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertArrayEquals(this.obj.getData(), result.getData());
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomSignatureFilter.java
@@ -18,13 +18,10 @@ package org.grad.secomv2.core.components;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.grad.secomv2.core.base.*;
+import org.grad.secomv2.core.interfaces.*;
 import org.grad.secomv2.core.models.*;
 import org.grad.secomv2.core.exceptions.SecomInvalidCertificateException;
 import org.grad.secomv2.core.exceptions.SecomSignatureVerificationException;
-import org.grad.secomv2.core.interfaces.AcknowledgementServiceInterface;
-import org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface;
-import org.grad.secomv2.core.interfaces.UploadLinkServiceInterface;
-import org.grad.secomv2.core.interfaces.UploadServiceInterface;
 import org.grad.secomv2.core.models.enums.DigitalSignatureAlgorithmEnum;
 import org.grad.secomv2.core.utils.PkiUtils;
 import org.grad.secomv2.core.utils.SecomPemUtils;
@@ -127,6 +124,10 @@ public class SecomSignatureFilter implements ContainerRequestFilter {
             // For the Encryption Key Interface Requests
             else if (rqstCtx.getUriInfo().getPath().endsWith(EncryptionKeyServiceInterface.ENCRYPTION_KEY_INTERFACE_PATH)) {
                 obj = this.parseRequestBody(rqstCtx, EncryptionKeyRequestObject.class);
+            }
+            // For the POST Get By Link Interface Requests
+            else if (rqstCtx.getUriInfo().getPath().endsWith(PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH)){
+                obj = this.parseRequestBody(rqstCtx, GetByLinkObject.class);
             }
         }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -41,6 +41,7 @@ import static org.grad.secomv2.core.interfaces.GetPublicKeyServiceInterface.GET_
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionServiceInterface.SUBSCRIPTION_INTERFACE_PATH;
@@ -140,6 +141,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     } else if(Objects.equals(this.request.getMethod(), "POST")) {
                         return UploadLinkServiceInterface.handleUploadLinkInterfaceExceptions(ex, this.request, null);
                     }
+                case POST_GET_BY_LINK_INTERFACE_PATH:
+                    return PostGetByLinkServiceInterface.handleGetByLinkInterfaceExceptions(ex, this.request, null);
                 case GET_INTERFACE_PATH: // Also for upload
                     if(Objects.equals(this.request.getMethod(), "GET")) {
                         return GetServiceInterface.handleGetInterfaceExceptions(ex, this.request, null);

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomInvalidCertificateException;
+import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.GetByLinkObject;
+import org.grad.secomv2.core.models.GetByLinkResponseObject;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
+    /**
+     * The Interface Endpoint Path.
+     */
+    String POST_GET_BY_LINK_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/object/search/link";
+
+    /**
+     * POST /v2/object/search/link : The POST Get By Link interface is used for pulling
+     * information from a data storage handled by the information owner. The
+     * link to the data storage can be exchanged with Upload Link interface.
+     * The owner of the information (provider) is responsible for relevant
+     * authentication and authorization procedure before returning information.
+     *
+     * @param getByLinkObject the get by link object
+     * @return get by link response object
+     */
+    @Path(POST_GET_BY_LINK_INTERFACE_PATH)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    GetByLinkResponseObject getByLink(@Valid GetByLinkObject getByLinkObject);
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleGetByLinkInterfaceExceptions(Exception ex,
+                                                       HttpServletRequest request,
+                                                       HttpServletResponse response) {
+        // Create the get by link response
+        Response.Status responseStatus = null;
+        String responseText = null;
+
+        // Handle according to the exception type
+        if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException
+                || ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatus = Response.Status.BAD_REQUEST;
+            responseText = "Bad Request";
+        } else if(ex instanceof SecomNotAuthorisedException) {
+            responseStatus = Response.Status.FORBIDDEN;
+            responseText = "Not authorized to requested information";
+        } else if(ex instanceof SecomInvalidCertificateException) {
+            responseStatus = Response.Status.FORBIDDEN;
+            responseText = "Invalid Certificate";
+        }  else if(ex instanceof SecomNotFoundException) {
+            responseStatus = Response.Status.NOT_FOUND;
+            responseText = String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier());
+        } else {
+            responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
+            responseText = responseStatus.getReasonPhrase();
+        }
+
+        // And send the error response back
+        return Response.status(responseStatus)
+                .entity(responseText)
+                .build();
+    }
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObject.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
+
+/**
+ * The SECOM Envelope Get By Link Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class EnvelopeGetByLinkObject extends AbstractEnvelope {
+    // Class Variables
+    @NotNull
+    @Schema(description = "Identifier uploaded in Upload Link")
+    private UUID transactionIdentifier;
+
+
+    /**
+     * Get transaction identifier.
+     *
+     * @return the transaction identifier
+     */
+    public UUID getTransactionIdentifier() {
+        return transactionIdentifier;
+    }
+
+    /**
+     * Sets transaction identifier.
+     *
+     * @param transactionIdentifier the transaction identifier
+     */
+    public void setTransactionIdentifier(UUID transactionIdentifier) {
+        this.transactionIdentifier = transactionIdentifier;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                transactionIdentifier,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetByLinkObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetByLinkObject.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * The SECOM Get By Link Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class GetByLinkObject implements EnvelopeSignatureBearer {
+    // Class Variables
+    @NotNull
+    private EnvelopeGetByLinkObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Gets envelope.
+     *
+     * @return the envelope
+     */
+    @Override
+    public EnvelopeGetByLinkObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets envelope.
+     *
+     * @param envelope the envelope
+     */
+    public void setEnvelope(EnvelopeGetByLinkObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets envelope signature.
+     *
+     * @return the envelope signature
+     */
+    @Override
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets envelope signature.
+     *
+     * @param digitalSignature the envelope signature
+     */
+    @Override
+    public void setEnvelopeSignature(String digitalSignature) {
+        this.envelopeSignature = digitalSignature;
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetByLinkResponseObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/GetByLinkResponseObject.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 AIVeNautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * The SECOM Get By Link Response Object Class.
+ *
+ * @author Junyeon Won (email: junyeon.won@aivenautics.com)
+ */
+public class GetByLinkResponseObject {
+    // Class Variables
+    @Schema(description = "Data as Base64 encoded binary format")
+    @NotNull
+    private byte[] data;
+
+    /**
+     * Gets data.
+     *
+     * @return the data
+     */
+    public byte[] getData() {
+        return data;
+    }
+
+    /**
+     * Sets data.
+     *
+     * @param data the data
+     */
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+}

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/EnvelopeGetByLinkObjectTest.java
@@ -1,0 +1,78 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvelopeGetByLinkObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetByLinkObject obj;
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Set up an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Generate a new object
+        this.obj = new EnvelopeGetByLinkObject();
+        this.obj.setTransactionIdentifier(UUID.randomUUID());
+
+        this.obj.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.obj.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.obj.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        EnvelopeGetByLinkObject result = this.mapper.readValue(jsonString, EnvelopeGetByLinkObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertEquals(this.obj.getTransactionIdentifier(), result.getTransactionIdentifier());
+        assertArrayEquals(this.obj.getEnvelopeSignatureCertificate(), result.getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), result.getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelopeSignatureTime(), result.getEnvelopeSignatureTime());
+    }
+
+    /**
+     * Test that we can correctly generate the SECOM signature CSV.
+     */
+    @Test
+    void testGetCsvString() {
+        // Generate the signature CSV
+        String signatureCSV = this.obj.getCsvString();
+
+        // Match the individual entries of the string
+        String[] csv = signatureCSV.split("\\.");
+        assertEquals(this.obj.getTransactionIdentifier().toString(), csv[0]);
+        assertEquals(Arrays.toString(this.obj.getEnvelopeSignatureCertificate()), csv[1]);
+        assertEquals(this.obj.getEnvelopeRootCertificateThumbprint(), csv[2]);
+        assertEquals(String.valueOf(this.obj.getEnvelopeSignatureTime().getEpochSecond()), csv[3]);
+    }
+}

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetByLinkObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetByLinkObjectTest.java
@@ -1,0 +1,70 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetByLinkObjectTest {
+    // Class Variables
+    private DigitalSignatureValueObject digitalSignatureValueObject;
+    private EnvelopeGetByLinkObject envelopeGetByLinkObject;
+    private GetByLinkObject obj;
+
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Set up an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Create a digital signature value
+        this.digitalSignatureValueObject = new DigitalSignatureValueObject();
+        this.digitalSignatureValueObject.setPublicRootCertificateThumbprint("thumbprint");
+        this.digitalSignatureValueObject.setPublicCertificate(new String[]{"certificate"});
+        this.digitalSignatureValueObject.setDigitalSignature("signature");
+
+        // Create a new envelope get filter object
+        this.envelopeGetByLinkObject = new EnvelopeGetByLinkObject();
+        this.envelopeGetByLinkObject.setTransactionIdentifier(UUID.randomUUID());
+        this.envelopeGetByLinkObject.setEnvelopeSignatureCertificate(new String[]{"envelopeCertificate"});
+        this.envelopeGetByLinkObject.setEnvelopeRootCertificateThumbprint("envelopeThumbprint");
+        this.envelopeGetByLinkObject.setEnvelopeSignatureTime(Instant.now().truncatedTo(ChronoUnit.SECONDS));
+
+        // Generate a new object
+        this.obj = new GetByLinkObject();
+        this.obj.setEnvelope(this.envelopeGetByLinkObject);
+        this.obj.setDigitalSignature("signature");
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetByLinkObject result = this.mapper.readValue(jsonString, GetByLinkObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertNotNull(result.getEnvelope());
+        assertEquals(this.obj.getEnvelope().getTransactionIdentifier(), result.getEnvelope().getTransactionIdentifier());
+        assertArrayEquals(this.obj.getEnvelope().getEnvelopeSignatureCertificate(), result.getEnvelope().getEnvelopeSignatureCertificate());
+        assertEquals(this.obj.getEnvelope().getEnvelopeRootCertificateThumbprint(), result.getEnvelope().getEnvelopeRootCertificateThumbprint());
+        assertEquals(this.obj.getEnvelope().getEnvelopeSignatureTime(), result.getEnvelope().getEnvelopeSignatureTime());
+        assertEquals(this.obj.getEnvelopeSignature(), result.getEnvelopeSignature());
+    }
+
+}

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetByLinkResponseObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/GetByLinkResponseObjectTest.java
@@ -1,0 +1,44 @@
+package org.grad.secomv2.core.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class GetByLinkResponseObjectTest {
+    // Class Variables
+    private GetByLinkResponseObject obj;
+    private ObjectMapper mapper;
+
+    /**
+     * Set up some base data.
+     */
+    @BeforeEach
+    void setup() {
+        //Set up an object mapper
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+
+        // Generate a new object
+        this.obj = new GetByLinkResponseObject();
+        this.obj.setData(new byte[0]);
+    }
+
+    /**
+     * Test that we can translate correctly the object onto JSON and back again.
+     */
+    @Test
+    void testJson() throws JsonProcessingException {
+        // Get the JSON format of the object
+        String jsonString = this.mapper.writeValueAsString(this.obj);
+        GetByLinkResponseObject result = this.mapper.readValue(jsonString, GetByLinkResponseObject.class);
+
+        // Make sure it looks OK
+        assertNotNull(result);
+        assertArrayEquals(this.obj.getData(), result.getData());
+    }
+}

--- a/secom-v2-springboot2/src/main/java/org/grad/secomv2/springboot2/components/SecomClient.java
+++ b/secom-v2-springboot2/src/main/java/org/grad/secomv2/springboot2/components/SecomClient.java
@@ -63,6 +63,7 @@ import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.RemoveSubscriptionServiceInterface.REMOVE_SUBSCRIPTION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
@@ -376,6 +377,28 @@ public class SecomClient {
                 .accept(MediaType.APPLICATION_OCTET_STREAM)
                 .retrieve()
                 .bodyToMono(byte[].class)
+                .blockOptional();
+    }
+
+    /**
+     * POST /v2/object/search/link : The Get By Link interface is used for pulling
+     * information using POST method from a data storage handled by the information owner. The
+     * link to the data storage can be exchanged with Upload Link interface.
+     * The owner of the information (provider) is responsible for relevant
+     * authentication and authorization procedure before returning information.
+     *
+     * @param getByLinkObject the get by link object
+     * @return the get by link response object
+     */
+    public Optional<GetByLinkResponseObject> postGetByLink(GetByLinkObject getByLinkObject) {
+        return this.secomClient
+                .post()
+                .uri(POST_GET_BY_LINK_INTERFACE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(getByLinkObject))
+                .retrieve()
+                .bodyToMono(GetByLinkResponseObject.class)
                 .blockOptional();
     }
 

--- a/secom-v2-springboot3/src/main/java/org/grad/secomv2/springboot3/components/SecomClient.java
+++ b/secom-v2-springboot3/src/main/java/org/grad/secomv2/springboot3/components/SecomClient.java
@@ -25,6 +25,7 @@ import org.grad.secomv2.core.base.SecomCertificateProvider;
 import org.grad.secomv2.core.base.SecomCompressionProvider;
 import org.grad.secomv2.core.base.SecomEncryptionProvider;
 import org.grad.secomv2.core.base.SecomSignatureProvider;
+import org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface;
 import org.grad.secomv2.core.models.*;
 import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
 import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
@@ -63,6 +64,7 @@ import static org.grad.secomv2.core.interfaces.GetByLinkServiceInterface.GET_BY_
 import static org.grad.secomv2.core.interfaces.GetServiceInterface.GET_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.GetSummaryServiceInterface.GET_SUMMARY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.RemoveSubscriptionServiceInterface.REMOVE_SUBSCRIPTION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
@@ -376,6 +378,28 @@ public class SecomClient {
                 .accept(MediaType.APPLICATION_OCTET_STREAM)
                 .retrieve()
                 .bodyToMono(byte[].class)
+                .blockOptional();
+    }
+
+    /**
+     * POST /v2/object/search/link : The Get By Link interface is used for pulling
+     * information using POST method from a data storage handled by the information owner. The
+     * link to the data storage can be exchanged with Upload Link interface.
+     * The owner of the information (provider) is responsible for relevant
+     * authentication and authorization procedure before returning information.
+     *
+     * @param getByLinkObject the get by link object
+     * @return the get by link response object
+     */
+    public Optional<GetByLinkResponseObject> postGetByLink(GetByLinkObject getByLinkObject) {
+        return this.secomClient
+                .post()
+                .uri(POST_GET_BY_LINK_INTERFACE_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(getByLinkObject))
+                .retrieve()
+                .bodyToMono(GetByLinkResponseObject.class)
                 .blockOptional();
     }
 


### PR DESCRIPTION
# Summary
Add POST-based Get By Link Interface (/v2/object/search/link) as specified in SECOM CD3

# Changes
- Introduce **PostGetByLinkServiceInterface** to support POST-based Get By Link Interface
  - Add POST /v2/object/search/link endpoint as defined in SECOM CD3
- Add **GetByLinkObject, EnvelopeGetByLinkObject and GetByLinkResponseObject**
  - Represent input data for the Get By Link Interface (Table 38, 39)
- Update **SecomSignatureFilter**
  - Add POST_GET_BY_LINK_INTERFACE_PATH for envelope signature verification of POST requests
- Update **SecomV2ExceptionMapper**
  - Add POST_GET_BY_LINK_INTERFACE_PATH for proper exception routing
- Extend **SecomClient**
  - Add postGetByLink() method for POST-based Get requests
- Apply all changes to both **javax and jakarta modules**
- Add tests
  - JSON serialization tests for model classes
  - CSV signature generation tests