### PR TITLE
Cd3 envelope retrieve result

### DIFF
--- a/secom-v2-core-jakarta/pom.xml
+++ b/secom-v2-core-jakarta/pom.xml
@@ -102,6 +102,18 @@
             <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>13.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
     

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -37,6 +37,7 @@ import static org.grad.secomv2.core.interfaces.AcknowledgementServiceInterface.A
 import static org.grad.secomv2.core.interfaces.CapabilityServiceInterface.CAPABILITY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PostGetServiceInterface.POST_GET_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.RetrieveResultServiceInterface.RETRIEVE_RESULT_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.EncryptionKeyNotifyServiceInterface.ENCRYPTION_KEY_NOTIFY_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.EncryptionKeyServiceInterface.ENCRYPTION_KEY_INTERFACE_PATH;
@@ -167,6 +168,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     }
                 case SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH:
                     return SubscriptionNotificationServiceInterface.handleSubscriptionNotificationInterfaceExceptions(ex, this.request, null);
+                case RETRIEVE_RESULT_INTERFACE_PATH:
+                    return RetrieveResultServiceInterface.handleRetrieveResultInterfaceExceptions(ex, this.request, null);
                 default:
                     //Nothing to do, continue with the generic rules
             }

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
@@ -22,20 +22,21 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
-import javax.validation.ValidationException;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.SearchResult;
 
 /**
  The SECOM Retrieve Result Interface Definition.
  *
  * @author Jakob Svenningsen (email: jakob@dmc.international)
  */
-public interface RetrieveResultsServiceInterface extends GenericSecomInterface {
+public interface RetrieveResultServiceInterface extends GenericSecomInterface {
 
     /**
      * The Interface Endpoint Path.
@@ -66,11 +67,11 @@ public interface RetrieveResultsServiceInterface extends GenericSecomInterface {
      * @return the handler response according to the SECOM standard
      */
     static Response handleRetrieveResultInterfaceExceptions(Exception ex,
-                                                           HttpServletRequest request,
-                                                           HttpServletResponse response) {
+                                                            HttpServletRequest request,
+                                                            HttpServletResponse response) {
 
         // Create the encryption key response
-        Response.Status responseStatus;
+        jakarta.ws.rs.core.Response.Status responseStatus;
         EncryptionKeyResponseObject encryptionKeyResponseObject = new EncryptionKeyResponseObject();
 
         // Handle according to the exception type

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 Digital Maritime Consultancy - A member of Team Aivenautics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeRetrieveResultObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeRetrieveResultObject.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+
+/**
+ * The SECOM Search Filter Object Class.
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public class EnvelopeRetrieveResultObject extends AbstractEnvelope {
+
+    // Class Variables
+    private String transactionId;
+
+    /**
+     * Gets transaction id.
+     *
+     * @return the transaction id
+     */
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    /**
+     * Sets transaction id.
+     *
+     * @param transactionId the transaction id
+     */
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                transactionId,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchFilterObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchFilterObject.java
@@ -36,7 +36,6 @@ public class EnvelopeSearchFilterObject extends AbstractEnvelope {
     @Schema(description = "The search geometry", type = "WKT", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
     @Pattern(regexp = "(^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$|^\\s*(\\{.*\\}|\\w+)\\s*$)")
     private String geometry;
-    private Boolean includeXml;
     private Boolean localOnly;
 
     /**
@@ -75,20 +74,6 @@ public class EnvelopeSearchFilterObject extends AbstractEnvelope {
         this.geometry = geometry;
     }
 
-    /**
-     * Get include xml
-     *
-     * @return include xml
-     */
-    public Boolean getIncludeXml() { return includeXml; }
-
-    /**
-     * Set include xml
-     *
-     * @param includeXml, whether xml should be included
-     */
-
-    public void setIncludeXml(Boolean includeXml) { this.includeXml = includeXml; }
 
     /**
      * Set local only search
@@ -131,7 +116,6 @@ public class EnvelopeSearchFilterObject extends AbstractEnvelope {
         return new Object[]{
                 query,
                 geometry,
-                includeXml,
                 localOnly,
                 envelopeSignatureCertificate,
                 envelopeRootCertificateThumbprint,

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The SECOM Envelope Search Result Object Class.
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public class EnvelopeSearchResultObject extends AbstractEnvelope {
+
+    @Schema(description = "The unique transaction ID of the search", requiredMode = Schema.RequiredMode.REQUIRED,
+            pattern = "^[{(]?[0-9a-fA-F]{8}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{12}[)}]?$",
+            example = "550e8400-e29b-41d4-a716-446655440000")
+    private UUID transactionId;
+
+    // Class Variables
+    private List<ServiceInstanceObject> serviceInstance;
+
+
+
+    /**
+     * Gets search service result.
+     *
+     * @return the search service result
+     */
+    public List<ServiceInstanceObject> getServiceInstance() {
+        return serviceInstance;
+    }
+
+    /**
+     * Sets search service result.
+     *
+     * @param serviceInstance the search service result
+     */
+    public void setServiceInstance(List<ServiceInstanceObject> serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    /**
+     * Get the transaction id
+     *
+     * @return the transaction id
+     */
+    public UUID getTransactionId() { return transactionId; }
+
+    /**
+     * Set the transaction id
+     *
+     * @param transactionId the transaction id
+     */
+    public void setTransactionId(UUID transactionId) { this.transactionId = transactionId; }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                transactionId,
+                serviceInstance,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 Digital Maritime Consultancy - A member of Team Aivenautics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/RetrieveResultObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/RetrieveResultObject.java
@@ -1,0 +1,56 @@
+
+package org.grad.secomv2.core.models;
+
+
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * {Description}
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public class RetrieveResultObject implements EnvelopeSignatureBearer {
+
+    @NotNull
+    private EnvelopeRetrieveResultObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Get the envelope
+     * @return envelope
+     */
+    public EnvelopeRetrieveResultObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets the envelope
+     *
+     * @param envelope the envelope search filter object
+     */
+    public void setEnvelope(EnvelopeRetrieveResultObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets the envelope signature
+     *
+     * @return envelopeSignature
+     */
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets the envelope signature
+     *
+     * @param envelopeSignature the envelope signature array
+     */
+    public void setEnvelopeSignature(String envelopeSignature) {
+        this.envelopeSignature = envelopeSignature;
+    }
+
+}

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/SearchResult.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/SearchResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2026 Digital Maritime Consultancy - A member of Team Aivenautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.grad.secomv2.core.models;
 
 import jakarta.validation.constraints.NotNull;

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/SearchResult.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/SearchResult.java
@@ -1,71 +1,44 @@
-/*
- * Copyright (c) 2025 GLA Research and Development Directorate
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.grad.secomv2.core.models;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.List;
-
 /**
- * The SECOM Search SearhResult Class.
+ * The SECOM Search Result  Class.
  *
  * @author Jakob Svenningsen (email: jakob@dmc.international)
  */
 public class SearchResult {
 
-    @Schema(description = "The unique transaction ID of the search", requiredMode = Schema.RequiredMode.REQUIRED,
-            pattern = "^[{(]?[0-9a-fA-F]{8}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{12}[)}]?$",
-            example = "550e8400-e29b-41d4-a716-446655440000")
     @NotNull
-    private String transactionId;
-
-    // Class Variables
-    private List<ServiceInstanceObject> serviceInstance;
-
-     /**
-     * Gets search service result.
-     *
-     * @return the search service result
-     */
-    public List<ServiceInstanceObject> getServiceInstance() {
-        return serviceInstance;
-    }
+    private EnvelopeSearchResultObject envelope;
+    @NotNull
+    private String envelopeSignature;
 
     /**
-     * Sets search service result.
-     *
-     * @param serviceInstance the search service result
+     * Get the envelope
+     * @return envelope
      */
-    public void setServiceInstance(List<ServiceInstanceObject> serviceInstance) {
-        this.serviceInstance = serviceInstance;
-    }
+    public EnvelopeSearchResultObject getEnvelope() {return envelope;}
 
     /**
-     * Get the transaction id
+     * Sets the envelope
      *
-     * @return the transaction id
+     * @param envelope the envelope search result object
      */
-    public String getTransactionId() { return transactionId; }
+    public void setEnvelope(EnvelopeSearchResultObject envelope) {this.envelope = envelope;}
 
     /**
-     * Set the transaction identifier
+     * Gets the envelope signature
      *
-     * @param transactionId the transaction identifier
+     * @return envelopeSignature
      */
-    public void setTransactionId(String transactionId) { this.transactionId = transactionId; }
+    public String getEnvelopeSignature() {return envelopeSignature;}
+
+    /**
+     * Sets the envelope signature
+     *
+     * @param envelopeSignature the envelope signature array
+     */
+    public void setEnvelopeSignature(String envelopeSignature) {this.envelopeSignature = envelopeSignature;}
+
 }

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
@@ -19,14 +19,12 @@ package org.grad.secomv2.core.models;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-
-import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.util.UUID;
 
 /**
- * The SECOM Service Instance Object Class.
+ * The SECOM Search Object Result Class.
  *
  * @author Nikolaos Vastardis (email: Nikolaos.Vastardis@gla-rad.org)
  */
@@ -49,12 +47,12 @@ public class ServiceInstanceObject {
     @NotNull
     private String organizationId;
     @NotNull
-    @Pattern(regexp = "^[a-zA-Z][a-zA-Z0-9+.\\-]*:(//[^/\\s?#]*)?([^\\s?#]*)(\\?[^#\\s]*)?(#\\S*)?$")
     private String endpointUri;
+    @NotNull
     private String[] endpointType;
     private String[] keywords;
     private String unlocode;
-    private String implementsDesigns;
+    private String implementsDesign;
     @NotNull
     @Pattern(regexp = "^(https?|ftp)://([a-zA-Z0-9\\-._~%!$&'()*+,;=]+@)?([a-zA-Z0-9\\-._~]+)(:\\d+)?(/[^\\s]*)?$")
     private String apiDoc;
@@ -63,8 +61,8 @@ public class ServiceInstanceObject {
     private String instanceAsXml;
     private String imo;
     private String mmsi;
-    private List<String> certificates;
-    private String sourceMSR;
+    private String[] certificates;
+    private String[] sourceMSRs;
     private String[] unsupportedParams;
 
 
@@ -272,17 +270,35 @@ public class ServiceInstanceObject {
      *
      * @return implementsDesign
      */
-    public String getImplementsDesigns() {
-        return implementsDesigns;
+    public String getImplementsDesign() {
+        return implementsDesign;
     }
 
     /**
      * Sets implements design
      *
-     * @param implementsDesigns the design
+     * @param implementsDesign the design
      */
-    public void setImplementsDesigns(String implementsDesigns) {
-        this.implementsDesigns = implementsDesigns;
+    public void setImplementsDesign(String implementsDesign) {
+        this.implementsDesign = implementsDesign;
+    }
+
+    /**
+     * Gets instance as xml.
+     *
+     * @return the instance as xml
+     */
+    public String getInstanceAsXml() {
+        return instanceAsXml;
+    }
+
+    /**
+     * Sets instance as xml.
+     *
+     * @param instanceAsXml the instance as xml
+     */
+    public void setInstanceAsXml(String instanceAsXml) {
+        this.instanceAsXml = instanceAsXml;
     }
 
     /**
@@ -321,23 +337,6 @@ public class ServiceInstanceObject {
         this.coverageArea = coverageArea;
     }
 
-    /**
-     * Gets instance as xml.
-     *
-     * @return the instance as xml
-     */
-    public String getInstanceAsXml() {
-        return instanceAsXml;
-    }
-
-    /**
-     * Sets instance as xml.
-     *
-     * @param instanceAsXml the instance as xml
-     */
-    public void setInstanceAsXml(String instanceAsXml) {
-        this.instanceAsXml = instanceAsXml;
-    }
 
     /**
      * Gets imo.
@@ -380,7 +379,7 @@ public class ServiceInstanceObject {
      *
      * @return certificates
      */
-    public List<String> getCertificates() {
+    public String[] getCertificates() {
         return certificates;
     }
 
@@ -389,17 +388,17 @@ public class ServiceInstanceObject {
      *
      * @param certificates the certificates
      */
-    public void setCertificates(List<String> certificates) {
+    public void setCertificates(String[] certificates) {
         this.certificates = certificates;
     }
 
     /**
      * Gets source MSRs.
      *
-     * @return the source MSRs
+     * @return the source msr
      */
-    public String getSourceMSR() {
-        return sourceMSR;
+    public String[] getSourceMSRs() {
+        return sourceMSRs;
     }
 
     /**
@@ -407,8 +406,8 @@ public class ServiceInstanceObject {
      *
      * @param sourceMSRs the source msr
      */
-    public void setSourceMSR(String sourceMSRs) {
-        this.sourceMSR = sourceMSRs;
+    public void setSourceMSRs(String[] sourceMSRs) {
+        this.sourceMSRs = sourceMSRs;
     }
 
     /**
@@ -428,5 +427,6 @@ public class ServiceInstanceObject {
     public void setUnsupportedParams(String[] unsupportedParams) {
         this.unsupportedParams = unsupportedParams;
     }
+
 
 }

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
@@ -52,7 +52,7 @@ public class ServiceInstanceObject {
     private String[] endpointType;
     private String[] keywords;
     private String[] unlocode;
-    private String implementsDesign;
+    private String[] implementsDesigns;
     @NotNull
     @Pattern(regexp = "^(https?|ftp)://([a-zA-Z0-9\\-._~%!$&'()*+,;=]+@)?([a-zA-Z0-9\\-._~]+)(:\\d+)?(/[^\\s]*)?$")
     private String apiDoc;
@@ -269,17 +269,17 @@ public class ServiceInstanceObject {
      *
      * @return implementsDesign
      */
-    public String getImplementsDesign() {
-        return implementsDesign;
+    public String[] getImplementsDesigns() {
+        return implementsDesigns;
     }
 
     /**
      * Sets implements design
      *
-     * @param implementsDesign the design
+     * @param implementsDesigns the design
      */
-    public void setImplementsDesign(String implementsDesign) {
-        this.implementsDesign = implementsDesign;
+    public void setImplementsDesigns(String[] implementsDesigns) {
+        this.implementsDesigns = implementsDesigns;
     }
 
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
@@ -58,7 +58,6 @@ public class ServiceInstanceObject {
     private String apiDoc;
     @NotNull
     private String[] coverageArea;
-    private String instanceAsXml;
     private String imo;
     private String mmsi;
     private String[] certificates;
@@ -283,23 +282,7 @@ public class ServiceInstanceObject {
         this.implementsDesign = implementsDesign;
     }
 
-    /**
-     * Gets instance as xml.
-     *
-     * @return the instance as xml
-     */
-    public String getInstanceAsXml() {
-        return instanceAsXml;
-    }
 
-    /**
-     * Sets instance as xml.
-     *
-     * @param instanceAsXml the instance as xml
-     */
-    public void setInstanceAsXml(String instanceAsXml) {
-        this.instanceAsXml = instanceAsXml;
-    }
 
     /**
      * Get api doc

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
@@ -51,7 +51,7 @@ public class ServiceInstanceObject {
     @NotNull
     private String[] endpointType;
     private String[] keywords;
-    private String unlocode;
+    private String[] unlocode;
     private String implementsDesign;
     @NotNull
     @Pattern(regexp = "^(https?|ftp)://([a-zA-Z0-9\\-._~%!$&'()*+,;=]+@)?([a-zA-Z0-9\\-._~]+)(:\\d+)?(/[^\\s]*)?$")
@@ -251,7 +251,7 @@ public class ServiceInstanceObject {
      *
      * @return the unlocode
      */
-    public String getUnlocode() {
+    public String[] getUnlocode() {
         return unlocode;
     }
 
@@ -260,7 +260,7 @@ public class ServiceInstanceObject {
      *
      * @param unlocode the unlocode
      */
-    public void setUnlocode(String unlocode) {
+    public void setUnlocode(String[] unlocode) {
         this.unlocode = unlocode;
     }
 

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
@@ -60,7 +60,7 @@ class ResponseSearchObjectTest {
         this.searchObjectResult.setEndpointType(new String[]{"endpointType"});
         this.searchObjectResult.setVersion("version");
         this.searchObjectResult.setKeywords(new String[]{"keywords"});
-        this.searchObjectResult.setUnlocode("unlocode");
+        this.searchObjectResult.setUnlocode(new String[]{"unlocode"});
         this.searchObjectResult.setMmsi("mmsi");
         this.searchObjectResult.setImo("imo");
         this.searchObjectResult.setSourceMSRs(new String[]{"sourceMSR"});

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
@@ -61,7 +61,6 @@ class ResponseSearchObjectTest {
         this.searchObjectResult.setVersion("version");
         this.searchObjectResult.setKeywords(new String[]{"keywords"});
         this.searchObjectResult.setUnlocode("unlocode");
-        this.searchObjectResult.setInstanceAsXml("instanceAsXml");
         this.searchObjectResult.setMmsi("mmsi");
         this.searchObjectResult.setImo("imo");
         this.searchObjectResult.setSourceMSRs(new String[]{"sourceMSR"});
@@ -96,7 +95,6 @@ class ResponseSearchObjectTest {
         assertEquals(this.obj.getSearchServiceResult().get(0).getVersion(), result.getSearchServiceResult().get(0).getVersion());
         assertArrayEquals(this.obj.getSearchServiceResult().get(0).getKeywords(), result.getSearchServiceResult().get(0).getKeywords());
         assertNotNull(result.getSearchServiceResult().get(0).getUnlocode());
-        assertEquals(this.obj.getSearchServiceResult().get(0).getInstanceAsXml(), result.getSearchServiceResult().get(0).getInstanceAsXml());
         assertEquals(this.obj.getSearchServiceResult().get(0).getMmsi(), result.getSearchServiceResult().get(0).getMmsi());
         assertEquals(this.obj.getSearchServiceResult().get(0).getImo(), result.getSearchServiceResult().get(0).getImo());
         assertArrayEquals(

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -63,7 +64,7 @@ class ResponseSearchObjectTest {
         this.searchObjectResult.setInstanceAsXml("instanceAsXml");
         this.searchObjectResult.setMmsi("mmsi");
         this.searchObjectResult.setImo("imo");
-        this.searchObjectResult.setSourceMSR("sourceMSR");
+        this.searchObjectResult.setSourceMSRs(new String[]{"sourceMSR"});
 
         // Generate a new object
         this.obj = new ResponseSearchObject();
@@ -98,8 +99,10 @@ class ResponseSearchObjectTest {
         assertEquals(this.obj.getSearchServiceResult().get(0).getInstanceAsXml(), result.getSearchServiceResult().get(0).getInstanceAsXml());
         assertEquals(this.obj.getSearchServiceResult().get(0).getMmsi(), result.getSearchServiceResult().get(0).getMmsi());
         assertEquals(this.obj.getSearchServiceResult().get(0).getImo(), result.getSearchServiceResult().get(0).getImo());
-        assertEquals(this.obj.getSearchServiceResult().get(0).getSourceMSR(), result.getSearchServiceResult().get(0).getSourceMSR());
-
+        assertArrayEquals(
+                this.obj.getSearchServiceResult().get(0).getSourceMSRs(),
+                result.getSearchServiceResult().get(0).getSourceMSRs()
+        );
     }
 
 }

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
@@ -58,7 +58,6 @@ class ServiceInstanceObjectTest {
         this.obj.setVersion("version");
         this.obj.setKeywords(new String[]{"keywords"});
         this.obj.setUnlocode("unlocode");
-        this.obj.setInstanceAsXml("instanceAsXml");
         this.obj.setMmsi("mmsi");
         this.obj.setImo("imo");
         this.obj.setCoverageArea(new String[] {"geometry"});
@@ -86,7 +85,6 @@ class ServiceInstanceObjectTest {
         assertEquals(this.obj.getVersion(), result.getVersion());
         assertArrayEquals(this.obj.getKeywords(), result.getKeywords());
         assertNotNull(result.getUnlocode());
-        assertEquals(this.obj.getInstanceAsXml(), result.getInstanceAsXml());
         assertEquals(this.obj.getMmsi(), result.getMmsi());
         assertEquals(this.obj.getImo(), result.getImo());
 

--- a/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
+++ b/secom-v2-core-jakarta/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
@@ -57,7 +57,7 @@ class ServiceInstanceObjectTest {
         this.obj.setEndpointType(new String[] {"endpointType"});
         this.obj.setVersion("version");
         this.obj.setKeywords(new String[]{"keywords"});
-        this.obj.setUnlocode("unlocode");
+        this.obj.setUnlocode(new String[]{"unlocode"});
         this.obj.setMmsi("mmsi");
         this.obj.setImo("imo");
         this.obj.setCoverageArea(new String[] {"geometry"});

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -44,7 +44,7 @@ import static org.grad.secomv2.core.interfaces.PostGetSummaryServiceInterface.PO
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PostGetServiceInterface.POST_GET_INTERFACE_PATH;
-import static org.grad.secomv2.core.interfaces.RetrieveResultsServiceInterface.RETRIEVE_RESULT_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.RetrieveResultServiceInterface.RETRIEVE_RESULT_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionServiceInterface.SUBSCRIPTION_INTERFACE_PATH;
@@ -175,7 +175,7 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                         return PostPublicKeyServiceInterface.handlePostPublicKeyInterfaceExceptions(ex, this.request, null);
                     }
                 case RETRIEVE_RESULT_INTERFACE_PATH:
-                    return RetrieveResultsServiceInterface.handleRetrieveResultInterfaceExceptions(ex, this.request, null);
+                    return RetrieveResultServiceInterface.handleRetrieveResultInterfaceExceptions(ex, this.request, null);
                 default:
                     //Nothing to do, continue with the generic rules
             }

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/components/SecomV2ExceptionMapper.java
@@ -44,6 +44,7 @@ import static org.grad.secomv2.core.interfaces.PostGetSummaryServiceInterface.PO
 import static org.grad.secomv2.core.interfaces.PingServiceInterface.PING_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PostGetByLinkServiceInterface.POST_GET_BY_LINK_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.PostGetServiceInterface.POST_GET_INTERFACE_PATH;
+import static org.grad.secomv2.core.interfaces.RetrieveResultsServiceInterface.RETRIEVE_RESULT_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SearchServiceServiceInterface.SEARCH_SERVICE_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionNotificationServiceInterface.SUBSCRIPTION_NOTIFICATION_INTERFACE_PATH;
 import static org.grad.secomv2.core.interfaces.SubscriptionServiceInterface.SUBSCRIPTION_INTERFACE_PATH;
@@ -173,6 +174,8 @@ public class SecomV2ExceptionMapper implements ExceptionMapper<Exception>, Conte
                     } else if(Objects.equals(this.request.getMethod(), "POST")) {
                         return PostPublicKeyServiceInterface.handlePostPublicKeyInterfaceExceptions(ex, this.request, null);
                     }
+                case RETRIEVE_RESULT_INTERFACE_PATH:
+                    return RetrieveResultsServiceInterface.handleRetrieveResultInterfaceExceptions(ex, this.request, null);
                 default:
                     //Nothing to do, continue with the generic rules
             }

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ The SECOM Retrieve Result Interface Definition.
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public interface RetrieveResultServiceInterface extends GenericSecomInterface {
+
+    /**
+     * The Interface Endpoint Path.
+     */
+    String RETRIEVE_RESULT_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/retrieveResult";
+
+    /**
+     * POST /v2/retrieveResult : The purpose of this interface is pull results of a
+     * search transaction for which more results may arrive asynchronously. The search
+     * transaction is identified by the transactionId field in the response to the iniitial
+     * searchService request.
+     *
+     * @param retrieveResultObject    The search filter object
+     * @return the result object
+     */
+    @Path(RETRIEVE_RESULT_INTERFACE_PATH)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    SearchResult retrieveResult(@Valid RetrieveResultObject retrieveResultObject);
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleRetrieveResultInterfaceExceptions(Exception ex,
+                                                           HttpServletRequest request,
+                                                           HttpServletResponse response) {
+
+        // Create the encryption key response
+        Response.Status responseStatus;
+        EncryptionKeyResponseObject encryptionKeyResponseObject = new EncryptionKeyResponseObject();
+
+        // Handle according to the exception type
+        if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException
+                || ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatus = Response.Status.BAD_REQUEST;
+            encryptionKeyResponseObject.setMessage("Bad Request");
+        } else if(ex instanceof SecomNotFoundException) {
+            responseStatus = Response.Status.NOT_FOUND;
+            encryptionKeyResponseObject.setMessage("Information not found");
+        } else {
+            responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
+            encryptionKeyResponseObject.setMessage(responseStatus.getReasonPhrase());
+        }
+
+        // And send the error response back
+        return Response.status(responseStatus)
+                .entity(encryptionKeyResponseObject)
+                .build();
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 Digital Maritime Consultancy - A member of Team Aivenautics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultsInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultsInterface.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.interfaces;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.grad.secomv2.core.base.SecomConstants;
+import org.grad.secomv2.core.exceptions.SecomNotFoundException;
+import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ The SECOM Retrieve Result Interface Definition.
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public interface RetrieveResultsInterface extends GenericSecomInterface {
+
+    /**
+     * The Interface Endpoint Path.
+     */
+    String RETRIEVE_RESULT_INTERFACE_PATH = "/" + SecomConstants.SECOM_VERSION + "/retrieveResult";
+
+    /**
+     * POST /v2/retrieveResult : The purpose of this interface is pull results of a
+     * search transaction for which more results may arrive asynchronously. The search
+     * transaction is identified by the transactionId field in the response to the iniitial
+     * searchService request.
+     *
+     * @param retrieveResultObject    The search filter object
+     * @return the result object
+     */
+    @Path(RETRIEVE_RESULT_INTERFACE_PATH)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    SearchResult retrieveResult(@Valid RetrieveResultObject retrieveResultObject);
+
+    /**
+     * The exception handler implementation for the interface.
+     *
+     * @param ex the exception that was raised
+     * @param request the request that cause the exception
+     * @param response the response for the request
+     * @return the handler response according to the SECOM standard
+     */
+    static Response handleRetrieveResultInterfaceExceptions(Exception ex,
+                                                           HttpServletRequest request,
+                                                           HttpServletResponse response) {
+
+        // Create the encryption key response
+        Response.Status responseStatus;
+        EncryptionKeyResponseObject encryptionKeyResponseObject = new EncryptionKeyResponseObject();
+
+        // Handle according to the exception type
+        if(ex instanceof SecomValidationException
+                || ex.getCause() instanceof SecomValidationException
+                || ex instanceof ValidationException
+                || ex instanceof JsonMappingException
+                || ex instanceof NotFoundException) {
+            responseStatus = Response.Status.BAD_REQUEST;
+            encryptionKeyResponseObject.setMessage("Bad Request");
+        } else if(ex instanceof SecomNotFoundException) {
+            responseStatus = Response.Status.NOT_FOUND;
+            encryptionKeyResponseObject.setMessage("Information not found");
+        } else {
+            responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
+            encryptionKeyResponseObject.setMessage(responseStatus.getReasonPhrase());
+        }
+
+        // And send the error response back
+        return Response.status(responseStatus)
+                .entity(encryptionKeyResponseObject)
+                .build();
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultsServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultsServiceInterface.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Jakob Svenningsen (email: jakob@dmc.international)
  */
-public interface RetrieveResultsInterface extends GenericSecomInterface {
+public interface RetrieveResultsServiceInterface extends GenericSecomInterface {
 
     /**
      * The Interface Endpoint Path.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
@@ -22,7 +22,7 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.EncryptionKeyResponseObject;
 import org.grad.secomv2.core.models.EnvelopeSearchFilterObject;
-import org.grad.secomv2.core.models.SearchResult;
+import org.grad.secomv2.core.models.EnvelopeSearchResultObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -59,7 +59,7 @@ public interface SearchServiceServiceInterface extends GenericSecomInterface {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    SearchResult searchService(@Valid EnvelopeSearchFilterObject envelopeSearchFilterObject);
+    EnvelopeSearchResultObject searchService(@Valid EnvelopeSearchFilterObject envelopeSearchFilterObject);
 
     /**
      * The exception handler implementation for the interface.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
@@ -20,9 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
-import org.grad.secomv2.core.models.EncryptionKeyResponseObject;
-import org.grad.secomv2.core.models.EnvelopeSearchFilterObject;
-import org.grad.secomv2.core.models.EnvelopeSearchResultObject;
+import org.grad.secomv2.core.models.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -52,14 +50,14 @@ public interface SearchServiceServiceInterface extends GenericSecomInterface {
      * POST /v2/searchService : The purpose of this interface is to search for
      * service instances to consume.
      *
-     * @param envelopeSearchFilterObject    The search filter object
+     * @param searchFilterObject    The search filter object
      * @return the result list of the search
      */
     @Path(SEARCH_SERVICE_INTERFACE_PATH)
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    EnvelopeSearchResultObject searchService(@Valid EnvelopeSearchFilterObject envelopeSearchFilterObject);
+    SearchResult searchService(@Valid SearchFilterObject searchFilterObject);
 
     /**
      * The exception handler implementation for the interface.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeRetrieveResultObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeRetrieveResultObject.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+
+/**
+ * The SECOM Search Filter Object Class.
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public class EnvelopeRetrieveResultObject extends AbstractEnvelope {
+
+    // Class Variables
+    private String transactionId;
+
+    /**
+     * Gets transaction id.
+     *
+     * @return the transaction id
+     */
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    /**
+     * Sets transaction id.
+     *
+     * @param transactionId the transaction id
+     */
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                transactionId,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchFilterObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchFilterObject.java
@@ -33,7 +33,6 @@ public class EnvelopeSearchFilterObject extends AbstractEnvelope {
     @Schema(description = "The search geometry", type = "WKT", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
     @Pattern(regexp = "(^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$|^\\s*(\\{.*\\}|\\w+)\\s*$)")
     private String geometry;
-    private Boolean includeXml;
     private Boolean localOnly;
 
     /**
@@ -72,19 +71,7 @@ public class EnvelopeSearchFilterObject extends AbstractEnvelope {
         this.geometry = geometry;
     }
 
-    /**
-     * Get include xml
-     *
-     * @return include xml
-     */
-    public Boolean getIncludeXml() { return includeXml; }
 
-    /**
-     * Set include xml
-     *
-     * @param includeXml, whether xml should be included
-     */
-    public void setIncludeXml(Boolean includeXml) { this.includeXml = includeXml; }
 
     /**
      * Get localOnly
@@ -105,7 +92,6 @@ public class EnvelopeSearchFilterObject extends AbstractEnvelope {
         return new Object[]{
                 query,
                 geometry,
-                includeXml,
                 localOnly,
                 envelopeSignatureCertificate,
                 envelopeRootCertificateThumbprint,

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grad.secomv2.core.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The SECOM Envelope Search Result Object Class.
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public class EnvelopeSearchResultObject extends AbstractEnvelope {
+
+    @Schema(description = "The unique transaction ID of the search", requiredMode = Schema.RequiredMode.REQUIRED,
+            pattern = "^[{(]?[0-9a-fA-F]{8}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{12}[)}]?$",
+            example = "550e8400-e29b-41d4-a716-446655440000")
+    private UUID transactionId;
+
+    // Class Variables
+    private List<ServiceInstanceObject> serviceInstance;
+
+     /**
+     * Gets search service result.
+     *
+     * @return the search service result
+     */
+    public List<ServiceInstanceObject> getServiceInstance() {
+        return serviceInstance;
+    }
+
+    /**
+     * Sets search service result.
+     *
+     * @param serviceInstance the search service result
+     */
+    public void setServiceInstance(List<ServiceInstanceObject> serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    /**
+     * Get the transaction id
+     *
+     * @return the transaction id
+     */
+    public UUID getTransactionId() { return transactionId; }
+
+    /**
+     * Set the transaction id
+     *
+     * @param transactionId the transaction id
+     */
+    public void setTransactionId(UUID transactionId) { this.transactionId = transactionId; }
+
+    @Override
+    public Object[] getAttributeArray() {
+        return new Object[]{
+                transactionId,
+                serviceInstance,
+                envelopeSignatureCertificate,
+                envelopeRootCertificateThumbprint,
+                envelopeSignatureTime,
+                digitalSignatureReference
+        };
+    }
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeSearchResultObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 Digital Maritime Consultancy - A member of Team Aivenautics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/RetrieveResultObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/RetrieveResultObject.java
@@ -1,0 +1,56 @@
+
+package org.grad.secomv2.core.models;
+
+
+import org.grad.secomv2.core.base.EnvelopeSignatureBearer;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * {Description}
+ *
+ * @author Jakob Svenningsen (email: jakob@dmc.international)
+ */
+public class RetrieveResultObject implements EnvelopeSignatureBearer {
+
+    @NotNull
+    private EnvelopeRetrieveResultObject envelope;
+    @NotNull
+    private String envelopeSignature;
+
+    /**
+     * Get the envelope
+     * @return envelope
+     */
+    public EnvelopeRetrieveResultObject getEnvelope() {
+        return envelope;
+    }
+
+    /**
+     * Sets the envelope
+     *
+     * @param envelope the envelope search filter object
+     */
+    public void setEnvelope(EnvelopeRetrieveResultObject envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * Gets the envelope signature
+     *
+     * @return envelopeSignature
+     */
+    public String getEnvelopeSignature() {
+        return envelopeSignature;
+    }
+
+    /**
+     * Sets the envelope signature
+     *
+     * @param envelopeSignature the envelope signature array
+     */
+    public void setEnvelopeSignature(String envelopeSignature) {
+        this.envelopeSignature = envelopeSignature;
+    }
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/SearchResult.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/SearchResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2026 Digital Maritime Consultancy - A member of Team Aivenautics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.grad.secomv2.core.models;
 
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/SearchResult.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/SearchResult.java
@@ -1,74 +1,45 @@
-/*
- * Copyright (c) 2025 GLA Research and Development Directorate
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.grad.secomv2.core.models;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.validation.constraints.NotNull;
-import java.util.List;
-import java.util.UUID;
 
 /**
- * The SECOM Search Result Class.
+ * The SECOM Search Result  Class.
  *
  * @author Jakob Svenningsen (email: jakob@dmc.international)
- */
+*/
 public class SearchResult {
 
-    @Schema(description = "The unique transaction ID of the search", requiredMode = Schema.RequiredMode.REQUIRED,
-            pattern = "^[{(]?[0-9a-fA-F]{8}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{4}[-]?[0-9a-fA-F]{12}[)}]?$",
-            example = "550e8400-e29b-41d4-a716-446655440000")
     @NotNull
-    private UUID transactionId;
-
-    // Class Variables
-    private List<ServiceInstanceObject> serviceInstance;
-
-     /**
-     * Gets search service result.
-     *
-     * @return the search service result
-     */
-    public List<ServiceInstanceObject> getServiceInstance() {
-        return serviceInstance;
-    }
+    private EnvelopeSearchResultObject envelope;
+    @NotNull
+    private String envelopeSignature;
 
     /**
-     * Sets search service result.
-     *
-     * @param serviceInstance the search service result
+     * Get the envelope
+     * @return envelope
      */
-    public void setServiceInstance(List<ServiceInstanceObject> serviceInstance) {
-        this.serviceInstance = serviceInstance;
-    }
+    public EnvelopeSearchResultObject getEnvelope() {return envelope;}
 
     /**
-     * Get the transaction id
+     * Sets the envelope
      *
-     * @return the transaction id
+     * @param envelope the envelope search result object
      */
-    public UUID getTransactionId() { return transactionId; }
+    public void setEnvelope(EnvelopeSearchResultObject envelope) {this.envelope = envelope;}
 
     /**
-     * Set the transaction id
+     * Gets the envelope signature
      *
-     * @param transactionId the transaction id
+     * @return envelopeSignature
      */
-    public void setTransactionId(UUID transactionId) { this.transactionId = transactionId; }
+    public String getEnvelopeSignature() {return envelopeSignature;}
 
+    /**
+     * Sets the envelope signature
+     *
+     * @param envelopeSignature the envelope signature array
+     */
+    public void setEnvelopeSignature(String envelopeSignature) {this.envelopeSignature = envelopeSignature;}
 
 }

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
@@ -58,7 +58,6 @@ public class ServiceInstanceObject {
     private String apiDoc;
     @NotNull
     private String[] coverageArea;
-    private String instanceAsXml;
     private String imo;
     private String mmsi;
     private String[] certificates;
@@ -283,23 +282,6 @@ public class ServiceInstanceObject {
         this.implementsDesign = implementsDesign;
     }
 
-    /**
-     * Gets instance as xml.
-     *
-     * @return the instance as xml
-     */
-    public String getInstanceAsXml() {
-        return instanceAsXml;
-    }
-
-    /**
-     * Sets instance as xml.
-     *
-     * @param instanceAsXml the instance as xml
-     */
-    public void setInstanceAsXml(String instanceAsXml) {
-        this.instanceAsXml = instanceAsXml;
-    }
 
     /**
      * Get api doc

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
@@ -52,7 +52,7 @@ public class ServiceInstanceObject {
     private String[] endpointType;
     private String[] keywords;
     private String[] unlocode;
-    private String implementsDesign;
+    private String[] implementsDesigns;
     @NotNull
     @Pattern(regexp = "^(https?|ftp)://([a-zA-Z0-9\\-._~%!$&'()*+,;=]+@)?([a-zA-Z0-9\\-._~]+)(:\\d+)?(/[^\\s]*)?$")
     private String apiDoc;
@@ -269,17 +269,17 @@ public class ServiceInstanceObject {
      *
      * @return implementsDesign
      */
-    public String getImplementsDesign() {
-        return implementsDesign;
+    public String[] getImplementsDesigns() {
+        return implementsDesigns;
     }
 
     /**
      * Sets implements design
      *
-     * @param implementsDesign the design
+     * @param implementsDesigns the design
      */
-    public void setImplementsDesign(String implementsDesign) {
-        this.implementsDesign = implementsDesign;
+    public void setImplementsDesigns(String[] implementsDesigns) {
+        this.implementsDesigns = implementsDesigns;
     }
 
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ServiceInstanceObject.java
@@ -51,7 +51,7 @@ public class ServiceInstanceObject {
     @NotNull
     private String[] endpointType;
     private String[] keywords;
-    private String unlocode;
+    private String[] unlocode;
     private String implementsDesign;
     @NotNull
     @Pattern(regexp = "^(https?|ftp)://([a-zA-Z0-9\\-._~%!$&'()*+,;=]+@)?([a-zA-Z0-9\\-._~]+)(:\\d+)?(/[^\\s]*)?$")
@@ -251,7 +251,7 @@ public class ServiceInstanceObject {
      *
      * @return the unlocode
      */
-    public String getUnlocode() {
+    public String[] getUnlocode() {
         return unlocode;
     }
 
@@ -260,7 +260,7 @@ public class ServiceInstanceObject {
      *
      * @param unlocode the unlocode
      */
-    public void setUnlocode(String unlocode) {
+    public void setUnlocode(String[] unlocode) {
         this.unlocode = unlocode;
     }
 

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
@@ -60,7 +60,6 @@ class ResponseSearchObjectTest {
         this.serviceInstanceObject.setVersion("version");
         this.serviceInstanceObject.setKeywords(new String[]{"keywords"});
         this.serviceInstanceObject.setUnlocode("unlocode");
-        this.serviceInstanceObject.setInstanceAsXml("instanceAsXml");
         this.serviceInstanceObject.setMmsi("mmsi");
         this.serviceInstanceObject.setImo("imo");
         this.serviceInstanceObject.setSourceMSRs(new String[]{"sourceMSR"});
@@ -95,7 +94,6 @@ class ResponseSearchObjectTest {
         assertEquals(this.obj.getSearchServiceResult().get(0).getVersion(), result.getSearchServiceResult().get(0).getVersion());
         assertArrayEquals(this.obj.getSearchServiceResult().get(0).getKeywords(), result.getSearchServiceResult().get(0).getKeywords());
         assertNotNull(result.getSearchServiceResult().get(0).getUnlocode());
-        assertEquals(this.obj.getSearchServiceResult().get(0).getInstanceAsXml(), result.getSearchServiceResult().get(0).getInstanceAsXml());
         assertEquals(this.obj.getSearchServiceResult().get(0).getMmsi(), result.getSearchServiceResult().get(0).getMmsi());
         assertEquals(this.obj.getSearchServiceResult().get(0).getImo(), result.getSearchServiceResult().get(0).getImo());
         assertArrayEquals(this.obj.getSearchServiceResult().get(0).getSourceMSRs(), result.getSearchServiceResult().get(0).getSourceMSRs());

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ResponseSearchObjectTest.java
@@ -59,7 +59,7 @@ class ResponseSearchObjectTest {
         this.serviceInstanceObject.setEndpointType(new String[] {"endpointType"});
         this.serviceInstanceObject.setVersion("version");
         this.serviceInstanceObject.setKeywords(new String[]{"keywords"});
-        this.serviceInstanceObject.setUnlocode("unlocode");
+        this.serviceInstanceObject.setUnlocode(new String[]{"unlocode"});
         this.serviceInstanceObject.setMmsi("mmsi");
         this.serviceInstanceObject.setImo("imo");
         this.serviceInstanceObject.setSourceMSRs(new String[]{"sourceMSR"});

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
@@ -57,7 +57,7 @@ class ServiceInstanceObjectTest {
         this.obj.setEndpointType(new String[] {"endpointType"});
         this.obj.setVersion("version");
         this.obj.setKeywords(new String[]{"keywords"});
-        this.obj.setUnlocode("unlocode");
+        this.obj.setUnlocode(new String[]{"unlocode"});
 
         this.obj.setMmsi("mmsi");
         this.obj.setImo("imo");

--- a/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
+++ b/secom-v2-core/src/test/java/org/grad/secomv2/core/models/ServiceInstanceObjectTest.java
@@ -58,7 +58,6 @@ class ServiceInstanceObjectTest {
         this.obj.setVersion("version");
         this.obj.setKeywords(new String[]{"keywords"});
         this.obj.setUnlocode("unlocode");
-        this.obj.setInstanceAsXml("instanceAsXml");
 
         this.obj.setMmsi("mmsi");
         this.obj.setImo("imo");
@@ -86,7 +85,6 @@ class ServiceInstanceObjectTest {
         assertEquals(this.obj.getVersion(), result.getVersion());
         assertArrayEquals(this.obj.getKeywords(), result.getKeywords());
         assertNotNull(result.getUnlocode());
-        assertEquals(this.obj.getInstanceAsXml(), result.getInstanceAsXml());
         assertEquals(this.obj.getMmsi(), result.getMmsi());
         assertEquals(this.obj.getImo(), result.getImo());
     }


### PR DESCRIPTION
Implements changes from the OpenAPI. Defines the object to be used when calling RetrieveResults. The object implementes EnvelopeSignatureBearer since the idea is that the consumer can prove their identity when retrieving results, such that the server can confirm that the consumer is auhtorized to pull the results on the provided UUID.