### PR TITLE
Correct @NotNull annotations based on SECOM CD3 spec multiplicity

### DIFF
--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeAccessNotificationObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeAccessNotificationObject.java
@@ -31,7 +31,6 @@ public class EnvelopeAccessNotificationObject extends AbstractEnvelope {
     private Boolean decision;
     @NotNull
     private String decisionReason;
-    @NotNull
     private UUID dataReference;
     @NotNull
     private UUID transactionIdentifier;

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
@@ -33,35 +33,25 @@ import java.util.UUID;
 public class EnvelopeGetFilterObject extends AbstractEnvelope {
 
     // Class Variables
-    @NotNull
     @Schema(description = "Reference to information object, e.g. from the Get Summary response")
     private UUID dataReference;
-    @NotNull
     private ContainerTypeEnum containerType;
-    @NotNull
     @Schema(description = "Data product type name requested, e.g. S-124, S-421")
     private SECOM_DataProductType dataProductType;
-    @NotNull
     @Schema(description = "S-100 based Product type version requested, e.g. 1.0.0")
     private String productVersion;
-    @NotNull
     @Schema(type = "string", description = "Geometry condition for geolocated information objects", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
     @Pattern(regexp = "^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$")
     private String geometry;
-    @NotNull
     @Schema(description = "Code of defined object", type = "string", example = "GBHRW")
     @Pattern(regexp = "[A-Z]{5}")
     private String unlocode;
-    @NotNull
     @Schema(description = "Valid from time")
     private Instant validFrom;
-    @NotNull
     @Schema(description = "Valid until time")
     private Instant validTo;
-    @NotNull
     @Schema(description = "Requested pagination page")
     private Integer page;
-    @NotNull
     @Schema(description = "Requested pagination page size")
     private Integer pageSize;
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeKeyObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/EnvelopeKeyObject.java
@@ -52,6 +52,7 @@ public class EnvelopeKeyObject extends AbstractEnvelope {
     private UUID transactionIdentifier;
     @NotNull
     private DigitalSignatureValueObject digitalSignatureValue;
+    @NotNull
     @Schema(description = "expiry time in UTC for the temporary key")
     private Instant expirationTime;
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/EnvelopeAccessNotificationObject.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/EnvelopeAccessNotificationObject.java
@@ -31,7 +31,6 @@ public class EnvelopeAccessNotificationObject extends AbstractEnvelope {
     private Boolean decision;
     @NotNull
     private String decisionReason;
-    @NotNull
     private UUID dataReference;
     @NotNull
     private UUID transactionIdentifier;

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
@@ -33,35 +33,25 @@ import java.util.UUID;
 public class EnvelopeGetFilterObject extends AbstractEnvelope {
 
     // Class Variables
-    @NotNull
     @Schema(description = "Reference to information object, e.g. from the Get Summary response")
     private UUID dataReference;
-    @NotNull
     private ContainerTypeEnum containerType;
-    @NotNull
     @Schema(description = "Data product type name requested, e.g. S-124, S-421")
     private SECOM_DataProductType dataProductType;
-    @NotNull
     @Schema(description = "S-100 based Product type version requested, e.g. 1.0.0")
     private String productVersion;
-    @NotNull
     @Schema(type = "string", description = "Geometry condition for geolocated information objects", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
     @Pattern(regexp = "^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$")
     private String geometry;
-    @NotNull
     @Schema(description = "Code of defined object", type = "string", example = "GBHRW")
     @Pattern(regexp = "[A-Z]{5}")
     private String unlocode;
-    @NotNull
     @Schema(description = "Valid from time")
     private Instant validFrom;
-    @NotNull
     @Schema(description = "Valid until time")
     private Instant validTo;
-    @NotNull
     @Schema(description = "Requested pagination page")
     private Integer page;
-    @NotNull
     @Schema(description = "Requested pagination page size")
     private Integer pageSize;
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/EnvelopeKeyObject.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/EnvelopeKeyObject.java
@@ -52,6 +52,7 @@ public class EnvelopeKeyObject extends AbstractEnvelope {
     private UUID transactionIdentifier;
     @NotNull
     private DigitalSignatureValueObject digitalSignatureValue;
+    @NotNull
     @Schema(description = "expiry time in UTC for the temporary key")
     private Instant expirationTime;
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeAccessNotificationObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeAccessNotificationObject.java
@@ -31,7 +31,6 @@ public class EnvelopeAccessNotificationObject extends AbstractEnvelope {
     private Boolean decision;
     @NotNull
     private String decisionReason;
-    @NotNull
     private UUID dataReference;
     @NotNull
     private UUID transactionIdentifier;

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeGetFilterObject.java
@@ -33,35 +33,25 @@ import java.util.UUID;
 public class EnvelopeGetFilterObject extends AbstractEnvelope {
 
     // Class Variables
-    @NotNull
     @Schema(description = "Reference to information object, e.g. from the Get Summary response")
     private UUID dataReference;
-    @NotNull
     private ContainerTypeEnum containerType;
-    @NotNull
     @Schema(description = "Data product type name requested, e.g. S-124, S-421")
     private SECOM_DataProductType dataProductType;
-    @NotNull
     @Schema(description = "S-100 based Product type version requested, e.g. 1.0.0")
     private String productVersion;
-    @NotNull
     @Schema(type = "string", description = "Geometry condition for geolocated information objects", example = "POLYGON ((0.65 51.42, 0.65 52.26, 2.68 52.26, 2.68 51.42, 0.65 51.42))")
     @Pattern(regexp = "^([A-Z]+\\s*\\(\\(?\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*(,\\s*(-?\\d+(\\.\\d+)?)\\s+-?\\d+(\\.\\d+)?(?:\\s+-?\\d+(\\.\\d+)?)?\\s*)*\\)\\)?\\s*)+$")
     private String geometry;
-    @NotNull
     @Schema(description = "Code of defined object", type = "string", example = "GBHRW")
     @Pattern(regexp = "[A-Z]{5}")
     private String unlocode;
-    @NotNull
     @Schema(description = "Valid from time")
     private Instant validFrom;
-    @NotNull
     @Schema(description = "Valid until time")
     private Instant validTo;
-    @NotNull
     @Schema(description = "Requested pagination page")
     private Integer page;
-    @NotNull
     @Schema(description = "Requested pagination page size")
     private Integer pageSize;
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeKeyObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/EnvelopeKeyObject.java
@@ -52,6 +52,7 @@ public class EnvelopeKeyObject extends AbstractEnvelope {
     private UUID transactionIdentifier;
     @NotNull
     private DigitalSignatureValueObject digitalSignatureValue;
+    @NotNull
     @Schema(description = "expiry time in UTC for the temporary key")
     private Instant expirationTime;
 


### PR DESCRIPTION
## Summary
Fix incorrect `@NotNull` annotations based on SECOM spec multiplicity (0..1 vs 1..1).

## Changes

### EnvelopeAccessNotificationObject
- `dataReference`: Remove @NotNull (0..1 optional field)

### EnvelopeGetFilterObject
- `dataReference`, `containerType`, `dataProductType`, `productVersion`,
  `geometry`, `unlocode`, `validFrom`, `validTo`, `page`, `pageSize`: Remove @NotNull (0..1 optional fields)

### EnvelopeKeyObject
- `expirationTime`: Add @NotNull (Mandatory field)

## Reason
Fields with 0..1 multiplicity should not have @NotNull as it causes 
validation failures for valid requests that do not include these optional fields.