### PR TITLE
Updated error condition responses to match the specification

### DIFF
--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
@@ -30,6 +30,7 @@ import jakarta.validation.ValidationException;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 /**
  * The SECOM Access Notification Interface Definition.
@@ -74,7 +75,7 @@ public interface AccessNotificationServiceInterface extends GenericSecomInterfac
                                                                 HttpServletResponse response) {
         // Create the access notification response
         Response.Status responseStatus;
-        AccessNotificationResponseObject accessNotificationResponseObject = new AccessNotificationResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,15 +85,15 @@ public interface AccessNotificationServiceInterface extends GenericSecomInterfac
                 || ex instanceof SecomNotFoundException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            accessNotificationResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            accessNotificationResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(accessNotificationResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
@@ -31,6 +31,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 /**
  * The SECOM Access Interface Definition.
@@ -74,7 +75,7 @@ public interface AccessServiceInterface extends GenericSecomInterface {
                                                     HttpServletResponse response) {
         // Create the access response
         Response.Status responseStatus;
-        AccessResponseObject accessResponseObject = new AccessResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,18 +85,18 @@ public interface AccessServiceInterface extends GenericSecomInterface {
                 || ex instanceof SecomNotFoundException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            accessResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            accessResponseObject.setMessage("Not authorized to requested information");
+            responseObject.setMessage("Not authorized to requested information");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            accessResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(accessResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AcknowledgementServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/AcknowledgementServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 /**
  * The SECOM Capability Interface Definition.
@@ -68,14 +69,14 @@ public interface CapabilityServiceInterface extends GenericSecomInterface {
                                                         HttpServletResponse response) {
         // Create the capability response
         Response.Status responseStatus;
-        CapabilityResponseObject capabilityResponseObject = new CapabilityResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(capabilityResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyRequestServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyRequestServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GenericSecomInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GenericSecomInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
@@ -31,6 +31,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
+
 import java.util.UUID;
 
 /**
@@ -77,7 +79,7 @@ public interface GetByLinkServiceInterface extends GenericSecomInterface {
                                                        HttpServletResponse response) {
         // Create the get by link response
         Response.Status responseStatus = null;
-        String responseText = null;
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -86,24 +88,24 @@ public interface GetByLinkServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            responseText = "Bad Request";
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Not authorized to requested information";
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomInvalidCertificateException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Invalid Certificate";
+            responseObject.setMessage("Invalid Certificate");
         }  else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            responseText = String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier());
+            responseObject.setMessage(String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier()));
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            responseText = responseStatus.getReasonPhrase();
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(responseText)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
@@ -34,6 +34,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 /**
  * The SECOM GET Public Key Interface Definition.
@@ -79,7 +80,7 @@ public interface GetPublicKeyServiceInterface extends GenericSecomInterface {
         Response.Status responseStatus;
 
         // Create the Public Key response
-        PublicKeyResponseObject publicKeyResponseObject = new PublicKeyResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -88,17 +89,20 @@ public interface GetPublicKeyServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
+            responseObject.setMessage("Not authorised to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
+            responseObject.setMessage("Not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(publicKeyResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -110,12 +110,10 @@ public interface GetServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -27,6 +27,7 @@ import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
 import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
 
@@ -101,7 +102,7 @@ public interface GetServiceInterface extends GenericSecomInterface {
                                                   HttpServletResponse response) {
         // Create the get response
         int responseStatus;
-        GetResponseObject getResponseObject = new GetResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -111,19 +112,23 @@ public interface GetServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -34,6 +34,7 @@ import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetSummaryResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
 import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
 
@@ -98,7 +99,7 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                                                         HttpServletResponse response) {
         // Create the get summary response
         int responseStatus;
-        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -108,19 +109,23 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable Content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorised to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getSummaryResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -107,12 +107,10 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable Content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorised to requested information");

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 /**
  * The SECOM Ping Interface Definition.
@@ -67,14 +68,14 @@ public interface PingServiceInterface extends GenericSecomInterface {
                                                   HttpServletResponse response) {
         // Create the ping response
         Response.Status responseStatus;
-        PingResponseObject pingResponseObject = new PingResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(pingResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
@@ -27,11 +27,12 @@ import org.grad.secomv2.core.models.GetByLinkResponseObject;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 /**
  * The SECOM POST Get By Link Interface Definition.
@@ -77,7 +78,7 @@ public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
                                                        HttpServletResponse response) {
         // Create the get by link response
         Response.Status responseStatus = null;
-        String responseText = null;
+        ResponseObject responseObject = new  ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -86,24 +87,24 @@ public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            responseText = "Bad Request";
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Not authorized to requested information";
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomInvalidCertificateException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Invalid Certificate";
+            responseObject.setMessage("Invalid Certificate");
         }  else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            responseText = String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier());
+            responseObject.setMessage(String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier()));
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            responseText = responseStatus.getReasonPhrase();
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(responseText)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -84,12 +84,10 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -32,6 +32,7 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 /**
  * The SECOM Get Interface Definition.
@@ -75,7 +76,7 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                                                 HttpServletResponse response) {
         // Create the get response
         int responseStatus;
-        GetResponseObject getResponseObject = new GetResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -85,19 +86,23 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -87,12 +87,10 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -19,8 +19,6 @@ package org.grad.secomv2.core.interfaces;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.ValidationException;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -31,6 +29,10 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetSummaryFilterObject;
 import org.grad.secomv2.core.models.GetSummaryResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ValidationException;
 
 /**
  * The SECOM POST Get Summary Interface Definition.
@@ -77,7 +79,7 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                                                         HttpServletResponse response) {
         // Create the get summary response
         int responseStatus;
-        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -87,19 +89,23 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getSummaryResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
@@ -29,6 +29,8 @@ import jakarta.validation.ValidationException;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
+
 import java.util.UUID;
 
 /**
@@ -75,7 +77,7 @@ public interface RemoveSubscriptionServiceInterface extends GenericSecomInterfac
                                                                 HttpServletResponse response) {
         // Create the remove subscription response
         Response.Status responseStatus;
-        RemoveSubscriptionResponseObject removeSubscriptionResponseObject = new RemoveSubscriptionResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,21 +86,21 @@ public interface RemoveSubscriptionServiceInterface extends GenericSecomInterfac
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            removeSubscriptionResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            removeSubscriptionResponseObject.setMessage("Not authorized to remove subscription");
+            responseObject.setMessage("Not authorized to remove subscription");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            removeSubscriptionResponseObject.setMessage("Subscriber identifier not found");
+            responseObject.setMessage("Subscriber identifier not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            removeSubscriptionResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(removeSubscriptionResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
@@ -71,7 +71,7 @@ public interface RetrieveResultServiceInterface extends GenericSecomInterface {
 
         // Create the encryption key response
         Response.Status responseStatus;
-        SearchResult searchResult = new SearchResult();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -80,18 +80,18 @@ public interface RetrieveResultServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            searchResult.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            searchResult.setMessage("Information not found");
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            searchResult.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(searchResult)
+                .entity(responseObject)
                 .build();
     }
 }

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import jakarta.ws.rs.*;
 import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.SubscriptionNotificationObject;
 import org.grad.secomv2.core.models.SubscriptionNotificationResponseObject;
 
@@ -73,7 +74,7 @@ public interface SubscriptionNotificationServiceInterface extends GenericSecomIn
                                                                       HttpServletResponse response) {
         // Create the subscription notification response
         Response.Status responseStatus;
-        SubscriptionNotificationResponseObject subscriptionNotificationResponseObject = new SubscriptionNotificationResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -82,15 +83,15 @@ public interface SubscriptionNotificationServiceInterface extends GenericSecomIn
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            subscriptionNotificationResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            subscriptionNotificationResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(subscriptionNotificationResponseObject)
+                .entity(responseObject)
                 .build();
     }
 }

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.SubscriptionRequestObject;
 import org.grad.secomv2.core.models.SubscriptionResponseObject;
 
@@ -74,7 +75,7 @@ public interface SubscriptionServiceInterface extends GenericSecomInterface {
                                                           HttpServletResponse response) {
         // Create the subscription response
         Response.Status responseStatus;
-        SubscriptionResponseObject subscriptionResponseObject = new SubscriptionResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -83,18 +84,18 @@ public interface SubscriptionServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            subscriptionResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            subscriptionResponseObject.setMessage("Not authorized to requested information");
+            responseObject.setMessage("Not authorized to requested information");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            subscriptionResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(subscriptionResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadLinkServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadLinkServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import static org.grad.secomv2.core.interfaces.GetPublicKeyServiceInterface.GET_PUBLIC_KEY_INTERFACE_PATH;
 
@@ -75,7 +76,7 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
         Response.Status responseStatus;
 
         // Create the Public Key response
-        PublicKeyResponseObject publicKeyResponseObject = new PublicKeyResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,17 +85,20 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
+            responseObject.setMessage("Not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(publicKeyResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -72,10 +72,8 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
     static Response handleUploadPublicKeyInterfaceExceptions(Exception ex,
                                                              HttpServletRequest request,
                                                              HttpServletResponse response) {
-        // Create the capability response
+        // Create the upload public key response
         Response.Status responseStatus;
-
-        // Create the Public Key response
         ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadServiceInterface.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/interfaces/UploadServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ResponseObject.java
+++ b/secom-v2-core-jakarta/src/main/java/org/grad/secomv2/core/models/ResponseObject.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grad.secomv2.core.models;
+
+
+/**
+ * Response Object used for error conditions
+ *
+ * @author Lawrence Hughes (email: Lawrence.Hughes@gla-rad.org)
+ */
+public class ResponseObject extends AbstractResponseObject {
+
+}

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/components/StringToContainerTypeConverterProvider.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/components/StringToContainerTypeConverterProvider.java
@@ -19,6 +19,7 @@ package org.grad.secomv2.core.components;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -40,8 +41,11 @@ public class StringToContainerTypeConverterProvider implements Converter<String,
      */
     @Override
     @NullMarked
-    public ContainerTypeEnum convert(String source) {
+    public @Nullable ContainerTypeEnum convert(String source) {
         try {
+            if(source.isEmpty()) {
+                return null;
+            }
             return ContainerTypeEnum.fromValue(Integer.parseInt(source));
         } catch (Exception ex) { // Direct to BAD_REQUEST
             throw new SecomValidationException(ex.getMessage());

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/components/StringToDataProductTypeConverterProvider.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/components/StringToDataProductTypeConverterProvider.java
@@ -17,9 +17,9 @@
 package org.grad.secomv2.core.components;
 
 import org.grad.secomv2.core.exceptions.SecomValidationException;
-import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
 import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -41,8 +41,11 @@ public class StringToDataProductTypeConverterProvider implements Converter<Strin
      */
     @Override
     @NullMarked
-    public SECOM_DataProductType convert(String source) {
+    public @Nullable SECOM_DataProductType convert(String source) {
         try {
+            if(source.isEmpty()) {
+                return null;
+            }
             return SECOM_DataProductType.fromString(source);
         } catch (Exception ex) { // Direct to BAD_REQUEST
             throw new SecomValidationException(ex.getMessage());

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
@@ -16,6 +16,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import tools.jackson.core.JacksonException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -75,9 +76,8 @@ public interface AccessNotificationServiceInterface extends GenericSecomInterfac
 
         // Create the access notification response
         HttpStatus httpStatus;
-        AccessNotificationResponseObject accessNotificationResponseObject = new AccessNotificationResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
-        // Handle according to the exception type
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
                 || ex.getCause() instanceof SecomValidationException
@@ -86,16 +86,16 @@ public interface AccessNotificationServiceInterface extends GenericSecomInterfac
                 || ex instanceof SecomNotFoundException
                 || ex instanceof HttpClientErrorException.NotFound
                 || ex instanceof JsonParseException) {
-            accessNotificationResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
             httpStatus = HttpStatus.BAD_REQUEST;
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            accessNotificationResponseObject.setMessage(httpStatus.getReasonPhrase());
+            responseObject.setMessage(httpStatus.getReasonPhrase());
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(accessNotificationResponseObject);
+                .body(responseObject);
 
     }
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
@@ -16,6 +16,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import tools.jackson.core.JacksonException;
 import org.grad.secomv2.core.base.SecomConstants;
@@ -73,10 +74,10 @@ public interface AccessServiceInterface extends GenericSecomInterface {
      * @return the handler response according to the SECOM standard
      */
     static ResponseEntity<Object> handleAccessInterfaceExceptions(Exception ex,
-                                                          HttpServletRequest request) {
+                                                                                 HttpServletRequest request) {
         // Create the access response
         HttpStatus httpStatus;
-        AccessResponseObject accessResponseObject = new AccessResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -86,19 +87,19 @@ public interface AccessServiceInterface extends GenericSecomInterface {
                 || ex instanceof SecomNotFoundException
                 || ex instanceof HttpClientErrorException.NotFound
                 || ex instanceof JsonParseException) {
-            accessResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
             httpStatus = HttpStatus.BAD_REQUEST;
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
-            accessResponseObject.setMessage("Not authorized to requested information");
+            responseObject.setMessage("Not authorized to requested information");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            accessResponseObject.setMessage(httpStatus.getReasonPhrase());
+            responseObject.setMessage(httpStatus.getReasonPhrase());
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(accessResponseObject);
+                .body(responseObject);
 
     }
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/AcknowledgementServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/AcknowledgementServiceInterface.java
@@ -121,7 +121,6 @@ public interface AcknowledgementServiceInterface extends GenericSecomInterface {
         return ResponseEntity
                 .status(httpStatus)
                 .body(acknowledgementResponseObject);
-
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
@@ -22,6 +22,7 @@ import org.grad.secomv2.core.models.CapabilityResponseObject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -66,7 +67,7 @@ public interface CapabilityServiceInterface extends GenericSecomInterface {
     static ResponseEntity<Object> handleCapabilityInterfaceExceptions(Exception ex,
                                                               HttpServletRequest request) {
         // Create the capability response
-        CapabilityResponseObject capabilityResponseObject = new CapabilityResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         HttpStatus httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
@@ -74,7 +75,7 @@ public interface CapabilityServiceInterface extends GenericSecomInterface {
         // And send the error response back
         return ResponseEntity
                 .status(httpStatus)
-                .body(capabilityResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyRequestServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyRequestServiceInterface.java
@@ -24,7 +24,6 @@ import org.grad.secomv2.core.models.EncryptionKeyRequestObject;
 import org.grad.secomv2.core.models.EncryptionKeyResponseObject;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import org.springframework.http.HttpStatus;

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyServiceInterface.java
@@ -24,7 +24,6 @@ import org.grad.secomv2.core.models.EncryptionKeyObject;
 import org.grad.secomv2.core.models.EncryptionKeyResponseObject;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import org.springframework.http.HttpStatus;

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
@@ -16,6 +16,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import tools.jackson.core.JacksonException;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -79,7 +80,7 @@ public interface GetByLinkServiceInterface extends GenericSecomInterface {
                                                                      HttpServletRequest request) {
         // Create a status object
         HttpStatus responseStatus;
-        String responseText;
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -88,25 +89,25 @@ public interface GetByLinkServiceInterface extends GenericSecomInterface {
                 || ex instanceof JacksonException
                 || ex instanceof HttpClientErrorException.NotFound) {
             responseStatus = HttpStatus.BAD_REQUEST;
-            responseText = "Bad Request";
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = HttpStatus.FORBIDDEN;
-            responseText = "Not authorized to requested information";
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomInvalidCertificateException) {
             responseStatus = HttpStatus.FORBIDDEN;
-            responseText = "Invalid certificate";
+            responseObject.setMessage("Invalid certificate");
         }  else if(ex instanceof SecomNotFoundException) {
             responseStatus = HttpStatus.NOT_FOUND;
-            responseText = String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier());
+            responseObject.setMessage(String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier()));
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            responseText = responseStatus.getReasonPhrase();
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return ResponseEntity
                 .status(responseStatus)
-                .body(responseText);
+                .body(responseObject);
 
     }
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
@@ -17,6 +17,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import tools.jackson.core.JacksonException;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -81,7 +82,7 @@ public interface GetPublicKeyServiceInterface extends GenericSecomInterface {
                                                                HttpServletRequest request) {
         // Create the capability response
         HttpStatus httpStatus;
-        PublicKeyResponseObject publicKeyResponseObject = new PublicKeyResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -90,17 +91,20 @@ public interface GetPublicKeyServiceInterface extends GenericSecomInterface {
                 || ex instanceof JacksonException
                 || ex instanceof HttpClientErrorException.NotFound) {
             httpStatus = HttpStatus.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             httpStatus = HttpStatus.NOT_FOUND;
+            responseObject.setMessage("Not found");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(publicKeyResponseObject);
+                .body(responseObject);
 
     }
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -18,6 +18,7 @@ package org.grad.secomv2.core.interfaces;
 
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.UnexpectedTypeException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import tools.jackson.core.JacksonException;
@@ -106,7 +107,7 @@ public interface GetServiceInterface extends GenericSecomInterface {
                                                                HttpServletRequest request) {
         // Create the get response
         HttpStatus httpStatus;
-        GetResponseObject getResponseObject = new GetResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -118,19 +119,23 @@ public interface GetServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof HandlerMethodValidationException) {
             httpStatus = HttpStatus.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException) {
             httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             httpStatus = HttpStatus.NOT_FOUND;
+            responseObject.setMessage("Information not found");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(getResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -117,12 +117,10 @@ public interface GetServiceInterface extends GenericSecomInterface {
                 || ex instanceof MethodArgumentTypeMismatchException
                 || ex instanceof UnexpectedTypeException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof HandlerMethodValidationException) {
+                || ex instanceof HandlerMethodValidationException
+                || ex instanceof ValidationException) {
             httpStatus = HttpStatus.BAD_REQUEST;
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException) {
-            httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -117,12 +117,10 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof MethodArgumentTypeMismatchException
                 || ex instanceof UnexpectedTypeException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof HandlerMethodValidationException) {
+                || ex instanceof HandlerMethodValidationException
+                || ex instanceof ValidationException) {
             httpStatus = HttpStatus.BAD_REQUEST;
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException) {
-            httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -18,6 +18,7 @@ package org.grad.secomv2.core.interfaces;
 
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.UnexpectedTypeException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -106,7 +107,7 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                                                                       HttpServletRequest request) {
         // Create the get summary response
         HttpStatus httpStatus;
-        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -118,19 +119,23 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof HandlerMethodValidationException) {
             httpStatus = HttpStatus.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException) {
             httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             httpStatus = HttpStatus.NOT_FOUND;
+            responseObject.setMessage("Information not found");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(getSummaryResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
@@ -20,6 +20,7 @@ import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.models.PingResponseObject;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -64,7 +65,7 @@ public interface PingServiceInterface extends GenericSecomInterface {
     static ResponseEntity<Object> handlePingInterfaceExceptions(Exception ex,
                                                   HttpServletRequest request) {
         // Create the ping response
-        PingResponseObject pingResponseObject = new PingResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         HttpStatus httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
@@ -72,7 +73,7 @@ public interface PingServiceInterface extends GenericSecomInterface {
         // And send the error response back
         return ResponseEntity
                 .status(httpStatus)
-                .body(pingResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
@@ -16,6 +16,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import tools.jackson.core.JacksonException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -80,7 +81,7 @@ public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
 
         // Create the return objects
         HttpStatus httpStatus;
-        GetByLinkResponseObject getByLinkResponseObject = new GetByLinkResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -90,19 +91,21 @@ public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
                 || ex instanceof HttpClientErrorException.NotFound
                 || ex instanceof JsonParseException) {
             httpStatus = HttpStatus.BAD_REQUEST;
-        } else if(ex instanceof SecomNotAuthorisedException) {
+            responseObject.setMessage("Bad request");
+        } else if(ex instanceof SecomNotAuthorisedException
+                || ex instanceof SecomInvalidCertificateException) {
             httpStatus = HttpStatus.FORBIDDEN;
-        } else if(ex instanceof SecomInvalidCertificateException) {
-            httpStatus = HttpStatus.FORBIDDEN;
-        }  else if(ex instanceof SecomNotFoundException) {
+            responseObject.setMessage("Not authorized to requested information");
+        } else if(ex instanceof SecomNotFoundException) {
             httpStatus = HttpStatus.NOT_FOUND;
+            responseObject.setMessage(String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier()));
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(getByLinkResponseObject);
+                .body(responseObject);
 
     }
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -91,12 +91,10 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                 || ex instanceof UnexpectedTypeException
                 || ex instanceof ConstraintViolationException
                 || ex instanceof HttpMessageNotReadableException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             httpStatus = HttpStatus.BAD_REQUEST;
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException) {
-            httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -18,6 +18,7 @@ package org.grad.secomv2.core.interfaces;
 
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.UnexpectedTypeException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -79,7 +80,7 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                                                               HttpServletRequest request) {
         // Create the get response
         HttpStatus httpStatus;
-        GetResponseObject getResponseObject = new GetResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -92,19 +93,23 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                 || ex instanceof HttpMessageNotReadableException
                 || ex instanceof IllegalArgumentException) {
             httpStatus = HttpStatus.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException) {
             httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             httpStatus = HttpStatus.NOT_FOUND;
+            responseObject.setMessage("Information not found");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(getResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -95,12 +95,10 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof UnexpectedTypeException
                 || ex instanceof ConstraintViolationException
                 || ex instanceof HttpMessageNotReadableException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             httpStatus = HttpStatus.BAD_REQUEST;
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException) {
-            httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -18,6 +18,7 @@ package org.grad.secomv2.core.interfaces;
 
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.UnexpectedTypeException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -83,7 +84,7 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                                                                       HttpServletRequest request) {
         // Create the get summary response
         HttpStatus httpStatus;
-        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -96,19 +97,23 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof HttpMessageNotReadableException
                 || ex instanceof IllegalArgumentException) {
             httpStatus = HttpStatus.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException) {
             httpStatus = HttpStatus.UNPROCESSABLE_CONTENT;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             httpStatus = HttpStatus.NOT_FOUND;
+            responseObject.setMessage("Information not found");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         return ResponseEntity
                 .status(httpStatus)
-                .body(getSummaryResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
@@ -16,6 +16,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import tools.jackson.core.JacksonException;
 import org.grad.secomv2.core.base.SecomConstants;
@@ -78,7 +79,7 @@ public interface RemoveSubscriptionServiceInterface extends GenericSecomInterfac
                                                                               HttpServletRequest request) {
         // Create the remove subscription response
         HttpStatus httpStatus;
-        RemoveSubscriptionResponseObject removeSubscriptionResponseObject = new RemoveSubscriptionResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -87,25 +88,25 @@ public interface RemoveSubscriptionServiceInterface extends GenericSecomInterfac
                 || ex instanceof JacksonException
                 || ex instanceof HttpClientErrorException.NotFound) {
             httpStatus = HttpStatus.BAD_REQUEST;
-            removeSubscriptionResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
-            removeSubscriptionResponseObject.setMessage("Not authorized to remove subscription");
+            responseObject.setMessage("Not authorized to remove subscription");
         } else if(ex instanceof SecomNotFoundException) {
             httpStatus = HttpStatus.NOT_FOUND;
-            removeSubscriptionResponseObject.setMessage("Subscriber identifier not found");
+            responseObject.setMessage("Subscriber identifier not found");
         } else if (ex instanceof MissingServletRequestParameterException){
             httpStatus = HttpStatus.NOT_FOUND;
-            removeSubscriptionResponseObject.setMessage("Missing required parameter");
+            responseObject.setMessage("Missing required parameter");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            removeSubscriptionResponseObject.setMessage(httpStatus.getReasonPhrase());
+            responseObject.setMessage(httpStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return ResponseEntity
                 .status(httpStatus)
-                .body(removeSubscriptionResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
@@ -74,7 +74,7 @@ public interface RetrieveResultServiceInterface extends GenericSecomInterface {
 
         // Create the encryption key response
         HttpStatus responseStatus;
-        SearchResult searchResult = new SearchResult();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,19 +84,19 @@ public interface RetrieveResultServiceInterface extends GenericSecomInterface {
                 || ex instanceof HttpClientErrorException.NotFound
                 || ex instanceof JsonParseException) {
             responseStatus = HttpStatus.BAD_REQUEST;
-            searchResult.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = HttpStatus.NOT_FOUND;
-            searchResult.setMessage("Information not found");
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            searchResult.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return ResponseEntity
                 .status(responseStatus)
-                .body(searchResult);
+                .body(responseObject);
 
     }
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
@@ -16,6 +16,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import tools.jackson.core.JacksonException;
 import org.grad.secomv2.core.base.SecomConstants;
@@ -74,7 +75,7 @@ public interface SubscriptionNotificationServiceInterface extends GenericSecomIn
                                                                       HttpServletRequest request) {
         // Create the subscription notification response
         HttpStatus httpStatus;
-        SubscriptionNotificationResponseObject subscriptionNotificationResponseObject = new SubscriptionNotificationResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,15 +85,15 @@ public interface SubscriptionNotificationServiceInterface extends GenericSecomIn
                 || ex instanceof HttpClientErrorException.NotFound
                 || ex instanceof JsonParseException) {
             httpStatus = HttpStatus.BAD_REQUEST;
-            subscriptionNotificationResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            subscriptionNotificationResponseObject.setMessage(httpStatus.getReasonPhrase());
+            responseObject.setMessage(httpStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return ResponseEntity
                 .status(httpStatus)
-                .body(subscriptionNotificationResponseObject);
+                .body(responseObject);
     }
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
@@ -16,6 +16,7 @@
 
 package org.grad.secomv2.core.interfaces;
 
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import tools.jackson.core.JacksonException;
@@ -77,7 +78,7 @@ public interface SubscriptionServiceInterface extends GenericSecomInterface {
                                                                         HttpServletRequest request) {
         // Create the subscription response
         HttpStatus httpStatus;
-        SubscriptionResponseObject subscriptionResponseObject = new SubscriptionResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -88,19 +89,19 @@ public interface SubscriptionServiceInterface extends GenericSecomInterface {
                 || ex instanceof MethodArgumentNotValidException
                 || ex instanceof JsonParseException) {
             httpStatus = HttpStatus.BAD_REQUEST;
-            subscriptionResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
-            subscriptionResponseObject.setMessage("Not authorized to requested information");
+            responseObject.setMessage("Not authorized to requested information");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            subscriptionResponseObject.setMessage(httpStatus.getReasonPhrase());
+            responseObject.setMessage(httpStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return ResponseEntity
                 .status(httpStatus)
-                .body(subscriptionResponseObject);
+                .body(responseObject);
     }
 
 }

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadLinkServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadLinkServiceInterface.java
@@ -77,7 +77,6 @@ public interface UploadLinkServiceInterface extends GenericSecomInterface {
      */
     static ResponseEntity<Object> handleUploadLinkInterfaceExceptions(Exception ex,
                                                               HttpServletRequest request) {
-
         // Create the upload link response
         HttpStatus httpStatus;
         UploadLinkResponseObject uploadResponseObject = new UploadLinkResponseObject();

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -75,7 +75,7 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
      */
     static ResponseEntity<Object> handlePostPublicKeyInterfaceExceptions(Exception ex,
                                                            HttpServletRequest request) {
-        // Create the upload link response
+        // Create the upload public key response
         HttpStatus httpStatus;
         ResponseObject responseObject = new ResponseObject();
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -18,6 +18,7 @@
 package org.grad.secomv2.core.interfaces;
 
 import org.grad.secomv2.core.exceptions.*;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.springframework.boot.json.JsonParseException;
 import tools.jackson.core.JacksonException;
 import jakarta.validation.Valid;
@@ -76,7 +77,7 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
                                                            HttpServletRequest request) {
         // Create the upload link response
         HttpStatus httpStatus;
-        PublicKeyResponseObject publicKeyResponseObject = new PublicKeyResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -86,10 +87,13 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
                 || ex instanceof HttpClientErrorException.NotFound
                 || ex instanceof JsonParseException) {
             httpStatus = HttpStatus.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             httpStatus = HttpStatus.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException){
             httpStatus = HttpStatus.NOT_FOUND;
+            responseObject.setMessage("Not found");
         } else {
             httpStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
@@ -97,7 +101,7 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
         // And send the error response back
         return ResponseEntity
                 .status(httpStatus)
-                .body(publicKeyResponseObject);
+                .body(responseObject);
 
     }
 

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadServiceInterface.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/interfaces/UploadServiceInterface.java
@@ -28,7 +28,6 @@ import org.grad.secomv2.core.models.UploadResponseObject;
 import org.grad.secomv2.core.models.enums.SECOM_ResponseCodeEnum;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import org.springframework.http.HttpStatus;

--- a/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/ResponseObject.java
+++ b/secom-v2-core-springboot/src/main/java/org/grad/secomv2/core/models/ResponseObject.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grad.secomv2.core.models;
+
+
+/**
+ * Response Object used for error conditions
+ *
+ * @author Lawrence Hughes (email: Lawrence.Hughes@gla-rad.org)
+ */
+public class ResponseObject extends AbstractResponseObject {
+
+}

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessNotificationServiceInterface.java
@@ -22,6 +22,7 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.AccessNotificationObject;
 import org.grad.secomv2.core.models.AccessNotificationResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -74,7 +75,7 @@ public interface AccessNotificationServiceInterface extends GenericSecomInterfac
                                                                 HttpServletResponse response) {
         // Create the access notification response
         Response.Status responseStatus;
-        AccessNotificationResponseObject accessNotificationResponseObject = new AccessNotificationResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,15 +85,15 @@ public interface AccessNotificationServiceInterface extends GenericSecomInterfac
                 || ex instanceof SecomNotFoundException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            accessNotificationResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            accessNotificationResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(accessNotificationResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AccessServiceInterface.java
@@ -23,6 +23,7 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.AccessRequestObject;
 import org.grad.secomv2.core.models.AccessResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -74,7 +75,7 @@ public interface AccessServiceInterface extends GenericSecomInterface {
                                                     HttpServletResponse response) {
         // Create the access response
         Response.Status responseStatus;
-        AccessResponseObject accessResponseObject = new AccessResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,18 +85,18 @@ public interface AccessServiceInterface extends GenericSecomInterface {
                 || ex instanceof SecomNotFoundException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            accessResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            accessResponseObject.setMessage("Not authorized to requested information");
+            responseObject.setMessage("Not authorized to requested information");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            accessResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(accessResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AcknowledgementServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/AcknowledgementServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/CapabilityServiceInterface.java
@@ -18,6 +18,7 @@ package org.grad.secomv2.core.interfaces;
 
 import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.models.CapabilityResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -68,14 +69,14 @@ public interface CapabilityServiceInterface extends GenericSecomInterface {
                                                         HttpServletResponse response) {
         // Create the capability response
         Response.Status responseStatus;
-        CapabilityResponseObject capabilityResponseObject = new CapabilityResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(capabilityResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyRequestServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyRequestServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/EncryptionKeyServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GenericSecomInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GenericSecomInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetByLinkServiceInterface.java
@@ -24,6 +24,7 @@ import org.grad.secomv2.core.exceptions.SecomInvalidCertificateException;
 import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -77,7 +78,7 @@ public interface GetByLinkServiceInterface extends GenericSecomInterface {
                                                        HttpServletResponse response) {
         // Create the get by link response
         Response.Status responseStatus = null;
-        String responseText = null;
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -86,24 +87,24 @@ public interface GetByLinkServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            responseText = "Bad Request";
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Not authorized to requested information";
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomInvalidCertificateException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Invalid Certificate";
+            responseObject.setMessage("Invalid Certificate");
         }  else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            responseText = String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier());
+            responseObject.setMessage(String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier()));
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            responseText = responseStatus.getReasonPhrase();
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(responseText)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetPublicKeyServiceInterface.java
@@ -24,8 +24,8 @@ import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
-import org.grad.secomv2.core.models.CapabilityResponseObject;
 import org.grad.secomv2.core.models.PublicKeyResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -79,7 +79,7 @@ public interface GetPublicKeyServiceInterface extends GenericSecomInterface {
         Response.Status responseStatus;
 
         // Create the Public Key response
-        PublicKeyResponseObject publicKeyResponseObject = new PublicKeyResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -88,17 +88,20 @@ public interface GetPublicKeyServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
+            responseObject.setMessage("Not authorised to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
+            responseObject.setMessage("Not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(publicKeyResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -109,12 +109,10 @@ public interface GetServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetServiceInterface.java
@@ -25,6 +25,7 @@ import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
 import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
 
@@ -100,7 +101,7 @@ public interface GetServiceInterface extends GenericSecomInterface {
                                                   HttpServletResponse response) {
         // Create the get response
         int responseStatus;
-        GetResponseObject getResponseObject = new GetResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -110,19 +111,23 @@ public interface GetServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -25,6 +25,7 @@ import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetSummaryResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.enums.ContainerTypeEnum;
 import org.grad.secomv2.core.models.enums.SECOM_DataProductType;
 
@@ -98,7 +99,7 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                                                         HttpServletResponse response) {
         // Create the get summary response
         int responseStatus;
-        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -108,19 +109,23 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable Content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorised to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getSummaryResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/GetSummaryServiceInterface.java
@@ -107,12 +107,10 @@ public interface GetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable Content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorised to requested information");

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PingServiceInterface.java
@@ -18,6 +18,7 @@ package org.grad.secomv2.core.interfaces;
 
 import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.models.PingResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -67,14 +68,14 @@ public interface PingServiceInterface extends GenericSecomInterface {
                                                   HttpServletResponse response) {
         // Create the ping response
         Response.Status responseStatus;
-        PingResponseObject pingResponseObject = new PingResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(pingResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetByLinkServiceInterface.java
@@ -24,6 +24,7 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetByLinkObject;
 import org.grad.secomv2.core.models.GetByLinkResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -77,7 +78,7 @@ public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
                                                        HttpServletResponse response) {
         // Create the get by link response
         Response.Status responseStatus = null;
-        String responseText = null;
+        ResponseObject responseObject = new  ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -86,24 +87,24 @@ public interface PostGetByLinkServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            responseText = "Bad Request";
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Not authorized to requested information";
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomInvalidCertificateException) {
             responseStatus = Response.Status.FORBIDDEN;
-            responseText = "Invalid Certificate";
+            responseObject.setMessage("Invalid Certificate");
         }  else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            responseText = String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier());
+            responseObject.setMessage(String.format("Information with %s not found", ((SecomNotFoundException) ex).getIdentifier()));
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            responseText = responseStatus.getReasonPhrase();
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(responseText)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -84,12 +84,10 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetServiceInterface.java
@@ -23,6 +23,7 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetFilterObject;
 import org.grad.secomv2.core.models.GetResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -75,7 +76,7 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                                                 HttpServletResponse response) {
         // Create the get response
         int responseStatus;
-        GetResponseObject getResponseObject = new GetResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -85,19 +86,23 @@ public interface PostGetServiceInterface extends GenericSecomInterface{
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -23,6 +23,7 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.GetSummaryFilterObject;
 import org.grad.secomv2.core.models.GetSummaryResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -78,7 +79,7 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                                                         HttpServletResponse response) {
         // Create the get summary response
         int responseStatus;
-        GetSummaryResponseObject getSummaryResponseObject = new GetSummaryResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -88,19 +89,23 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof ConstraintViolationException
                 || ex instanceof IllegalArgumentException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof ValidationException){
             responseStatus = 422;
+            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND.getStatusCode();
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex).getStatusCode();
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(getSummaryResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/PostGetSummaryServiceInterface.java
@@ -87,12 +87,10 @@ public interface PostGetSummaryServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException
                 || ex instanceof ConstraintViolationException
-                || ex instanceof IllegalArgumentException) {
+                || ex instanceof IllegalArgumentException
+                || ex instanceof ValidationException) {
             responseStatus = Response.Status.BAD_REQUEST.getStatusCode();
             responseObject.setMessage("Bad request");
-        } else if(ex instanceof ValidationException){
-            responseStatus = 422;
-            responseObject.setMessage("Unprocessable content");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN.getStatusCode();
             responseObject.setMessage("Not authorized to requested information");

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RemoveSubscriptionServiceInterface.java
@@ -22,6 +22,7 @@ import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.RemoveSubscriptionResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -75,7 +76,7 @@ public interface RemoveSubscriptionServiceInterface extends GenericSecomInterfac
                                                                 HttpServletResponse response) {
         // Create the remove subscription response
         Response.Status responseStatus;
-        RemoveSubscriptionResponseObject removeSubscriptionResponseObject = new RemoveSubscriptionResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,21 +85,21 @@ public interface RemoveSubscriptionServiceInterface extends GenericSecomInterfac
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            removeSubscriptionResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            removeSubscriptionResponseObject.setMessage("Not authorized to remove subscription");
+            responseObject.setMessage("Not authorized to remove subscription");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            removeSubscriptionResponseObject.setMessage("Subscriber identifier not found");
+            responseObject.setMessage("Subscriber identifier not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            removeSubscriptionResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(removeSubscriptionResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/RetrieveResultServiceInterface.java
@@ -71,7 +71,7 @@ public interface RetrieveResultServiceInterface extends GenericSecomInterface {
 
         // Create the encryption key response
         Response.Status responseStatus;
-        SearchResult searchResult = new SearchResult();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -80,18 +80,18 @@ public interface RetrieveResultServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            searchResult.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
-            searchResult.setMessage("Information not found");
+            responseObject.setMessage("Information not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            searchResult.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(searchResult)
+                .entity(responseObject)
                 .build();
     }
 }

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SearchServiceServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionNotificationServiceInterface.java
@@ -19,6 +19,7 @@ package org.grad.secomv2.core.interfaces;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.SubscriptionNotificationObject;
 import org.grad.secomv2.core.models.SubscriptionNotificationResponseObject;
 
@@ -73,7 +74,7 @@ public interface SubscriptionNotificationServiceInterface extends GenericSecomIn
                                                                       HttpServletResponse response) {
         // Create the subscription notification response
         Response.Status responseStatus;
-        SubscriptionNotificationResponseObject subscriptionNotificationResponseObject = new SubscriptionNotificationResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -82,15 +83,15 @@ public interface SubscriptionNotificationServiceInterface extends GenericSecomIn
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            subscriptionNotificationResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            subscriptionNotificationResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(subscriptionNotificationResponseObject)
+                .entity(responseObject)
                 .build();
     }
 }

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/SubscriptionServiceInterface.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import org.grad.secomv2.core.base.SecomConstants;
 import org.grad.secomv2.core.exceptions.SecomNotAuthorisedException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
+import org.grad.secomv2.core.models.ResponseObject;
 import org.grad.secomv2.core.models.SubscriptionRequestObject;
 import org.grad.secomv2.core.models.SubscriptionResponseObject;
 
@@ -74,7 +75,7 @@ public interface SubscriptionServiceInterface extends GenericSecomInterface {
                                                           HttpServletResponse response) {
         // Create the subscription response
         Response.Status responseStatus;
-        SubscriptionResponseObject subscriptionResponseObject = new SubscriptionResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -83,18 +84,18 @@ public interface SubscriptionServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
-            subscriptionResponseObject.setMessage("Bad Request");
+            responseObject.setMessage("Bad Request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
-            subscriptionResponseObject.setMessage("Not authorized to requested information");
+            responseObject.setMessage("Not authorized to requested information");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
-            subscriptionResponseObject.setMessage(responseStatus.getReasonPhrase());
+            responseObject.setMessage(responseStatus.getReasonPhrase());
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(subscriptionResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadLinkServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadLinkServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -72,10 +72,8 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
     static Response handleUploadPublicKeyInterfaceExceptions(Exception ex,
                                                              HttpServletRequest request,
                                                              HttpServletResponse response) {
-        // Create the capability response
+        // Create the upload public key response
         Response.Status responseStatus;
-
-        // Create the Public Key response
         ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadPublicKeyServiceInterface.java
@@ -22,6 +22,7 @@ import org.grad.secomv2.core.exceptions.SecomNotFoundException;
 import org.grad.secomv2.core.exceptions.SecomValidationException;
 import org.grad.secomv2.core.models.PublicKeyRequestObject;
 import org.grad.secomv2.core.models.PublicKeyResponseObject;
+import org.grad.secomv2.core.models.ResponseObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -75,7 +76,7 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
         Response.Status responseStatus;
 
         // Create the Public Key response
-        PublicKeyResponseObject publicKeyResponseObject = new PublicKeyResponseObject();
+        ResponseObject responseObject = new ResponseObject();
 
         // Handle according to the exception type
         if(ex instanceof SecomValidationException
@@ -84,17 +85,20 @@ public interface UploadPublicKeyServiceInterface extends GenericSecomInterface {
                 || ex instanceof JsonMappingException
                 || ex instanceof NotFoundException) {
             responseStatus = Response.Status.BAD_REQUEST;
+            responseObject.setMessage("Bad request");
         } else if(ex instanceof SecomNotAuthorisedException) {
             responseStatus = Response.Status.FORBIDDEN;
+            responseObject.setMessage("Not authorized to requested information");
         } else if(ex instanceof SecomNotFoundException) {
             responseStatus = Response.Status.NOT_FOUND;
+            responseObject.setMessage("Not found");
         } else {
             responseStatus = GenericSecomInterface.handleCommonExceptionResponseCode(ex);
         }
 
         // And send the error response back
         return Response.status(responseStatus)
-                .entity(publicKeyResponseObject)
+                .entity(responseObject)
                 .build();
     }
 

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadServiceInterface.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/interfaces/UploadServiceInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 GLA Research and Development Directorate
+ * Copyright (c) 2026 GLA Research and Development Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ResponseObject.java
+++ b/secom-v2-core/src/main/java/org/grad/secomv2/core/models/ResponseObject.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 GLA Research and Development Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grad.secomv2.core.models;
+
+
+/**
+ * Response Object used for error conditions
+ *
+ * @author Lawrence Hughes (email: Lawrence.Hughes@gla-rad.org)
+ */
+public class ResponseObject extends AbstractResponseObject {
+
+}


### PR DESCRIPTION
Updated error handling to match responses with the specification. 

Added a new object 'ResponseObject' which is used by: 
POST /v2/access
POST /v2/access/notification
GET /v2/capability
GET /v2/object
POST /v2/object/search
GET /v2/object/summary
POST /v2/object/search/summary
GET /v2/ping
GET /v2/publicKey
POST /v2/publicKey
POST /v2/subscription
DELETE /v2/subscription
POST /v2/subscription/notification

Other interfaces return a specific response with a SECOM_ResponseCode field:
POST /v2/acknowledgement
POST /v2/encryptionKey/request
POST /v2/encryptionKey
POST /v2/object
GET /v2/object/link
POST /v2/object/link
POST /v2/object/search/link

I have updated the copyright date on interfaces to show they have been checked.